### PR TITLE
Adiciona suporte a outras formas de empacotamento e mais

### DIFF
--- a/.var/app/org.gimp.GIMP/config/GIMP/2.10/sessionrc
+++ b/.var/app/org.gimp.GIMP/config/GIMP/2.10/sessionrc
@@ -1,29 +1,39 @@
-# GIMP sessionrc
-# 
-# This file takes session-specific info (that is info, you want to keep
-# between two GIMP sessions).  You are not supposed to edit it manually, but
-# of course you can do.  The sessionrc will be entirely rewritten every time
-# you quit GIMP.  If this file isn't found, defaults are used.
-
+#
+#    Por favor certifique se de manter esse 
+#    arquivo assim antes de fazer uma 
+#    nova release
+#
+#------------------------------------------------------------------------------------
+#
+#    Esse arquivo serve para salvar as posições.
+#    O problema é que o monitor usado para criar o patch é de altissima resolução
+#    o que faz com que  janelas fiquem fora de posição e até impossivel de serem
+#    acessadas em monitores com resolução mais baixa por exemplo na resolução 
+#    1360x768 a própria janela do GIMP fica quase fora da tela, esse commit torna
+#    o Layout compatível com a maioria das resoluções desde as mais baixas
+#    até as mais altas
+#    
+#
+#------------------------------------------------------------------------------------
+#
 (session-info "toplevel"
     (factory-entry "gimp-empty-image-window")
-    (position 410 370)
-    (size 620 200))
+    (position 0 0))
 (session-info "toplevel"
     (factory-entry "gimp-single-image-window")
-    (position 255 82)
-    (size 1920 856)
+    (position 0 0)
+    (size 1280 600)
     (open-on-exit)
     (aux-info
-        (left-docks-width "52")
-        (right-docks-width "363")
-        (maximized "no"))
+        (left-docks-width "44")
+        (right-docks-width "313")
+        (maximized "yes"))
     (gimp-toolbox
         (side left))
     (gimp-dock
         (side right)
         (book
-            (current-page 0)
+            (current-page 1)
             (dockable "gimp-tool-options"
                 (tab-style automatic)
                 (aux-info
@@ -31,9 +41,13 @@
             (dockable "gimp-font-list"
                 (tab-style automatic)
                 (aux-info
+                    (show-button-bar "true")))
+            (dockable "gimp-undo-history"
+                (tab-style automatic)
+                (aux-info
                     (show-button-bar "true"))))
         (book
-            (position 492)
+            (position 340)
             (current-page 0)
             (dockable "gimp-layer-list"
                 (tab-style automatic)
@@ -47,63 +61,28 @@
                     (show-button-bar "true"))))))
 (session-info "toplevel"
     (factory-entry "gimp-image-new-dialog")
-    (position 943 278))
-(session-info "toplevel"
-    (factory-entry "gimp-keyboard-shortcuts-dialog")
-    (position 1431 198)
-    (size 929 676))
-(session-info "toplevel"
-    (factory-entry "gimp-input-devices-dialog")
-    (position 0 497))
-(session-info "toplevel"
-    (factory-entry "gimp-preferences-dialog")
-    (position 1033 245)
-    (size 1008 692))
-(session-info "toplevel"
-    (factory-entry "gimp-file-save-dialog")
-    (position 73 146)
-    (size 1128 782)
-    (monitor 1))
-(session-info "toplevel"
-    (factory-entry "gimp-file-open-dialog")
-    (position 319 77)
-    (size 1128 782)
-    (monitor 1))
-(session-info "toplevel"
-    (factory-entry "gimp-file-export-dialog")
-    (position 522 99)
-    (size 1128 782))
-(session-info "toplevel"
-    (factory-entry "gimp-module-dialog")
-    (position 268 330)
-    (size 671 476))
+    (position 0 0))
 (session-info "toplevel"
     (factory-entry "gimp-toolbox-color-dialog")
-    (position 308 0))
+    (position 0 0))
 (session-info "toplevel"
     (factory-entry "gimp-operation-tool-dialog")
-    (position 1518 93))
+    (position 0 0))
 (session-info "toplevel"
-    (factory-entry "gimp-threshold-tool-dialog")
-    (position 467 474))
+    (factory-entry "gimp-file-save-dialog")
+    (position 0 0)
+    (size 800 600))
 (session-info "toplevel"
-    (factory-entry "gimp-curves-tool-dialog")
-    (position 1849 92)
-    (size 446 605))
+    (factory-entry "gimp-file-open-dialog")
+    (position 0 0)
+    (size 800 600))
 (session-info "toplevel"
-    (factory-entry "gimp-action-search-dialog")
-    (position 812 260)
-    (size 983 540)
-    (monitor 1))
-(session-info "toplevel"
-    (factory-entry "gimp-levels-tool-dialog")
-    (position 1635 99)
-    (size 462 593))
+    (factory-entry "gimp-preferences-dialog")
+    (position 0 0)
+    (size 1019 634))
 
 (hide-docks no)
 (single-window-mode yes)
 (show-tabs yes)
 (tabs-position 0)
 (last-tip-shown 0)
-
-# end of sessionrc

--- a/How to Install PhotoGIMP's Patch.txt
+++ b/How to Install PhotoGIMP's Patch.txt
@@ -1,7 +1,9 @@
-Just Extract all *hidden* folder to your home repository
+For linux users run:
 
-.icons
-.var
-.local
+  bash install_linux.sh
+  
+For windows users run:
 
-Only works with flatpak version for GIMP.
+  install_windows.bat
+
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,16 @@
-![](https://github.com/Diolinux/PhotoGIMP/blob/master/.var/app/org.gimp.GIMP/config/GIMP/2.10/splashes/photogimp-diolinux-splash.png)
+<h1 align="center">
+  <img src="https://github.com/Diolinux/PhotoGIMP/blob/master/.icons/photogimp.png" alt="GIMP" width="256" height="256">
+  <br />
+  PhotoGIMP <br/>
+  <h3 align="center">Download: <a href="https://github.com/Diolinux/PhotoGIMP/releases/download/1.0/PhotoGIMP.by.Diolinux.v2020.for.Flatpak.zip">Patch</a> | <a href="https://github.com/sudo-give-me-coffee/PhotoGIMP/releases/download/continuous/PhotoGIMP-x86_64.AppImage">AppImage</a></h3>
+</h1>
 
-# PhotoGIMP
+<p align="center"><i>"The GIMP for those who come from Adobe Photoshop for Windows"</i>.<br> Original work</p>
+
+<hr>
+
+### What is?
+
 A simple Patch for GIMP 2.10+ to help all Photoshop Users.
 
 * Tool organization to mimic the position of Adobe's Photoshop;
@@ -17,24 +27,31 @@ It should looks like this:
 ![](https://github.com/Diolinux/PhotoGIMP/blob/master/2020-06-22_12-06.png
 )
 
-
-<img src="https://github.com/Diolinux/PhotoGIMP/blob/master/.icons/photogimp.png" data-canonical-src="https://github.com/Diolinux/PhotoGIMP/blob/master/.icons/photogimp.png" width="200" height="200" />
-
-## Included Fonts
+### Included Fonts
 
 https://github.com/Diolinux/PhotoGIMP/blob/master/fonts.txt
 
-# How to Install
+### How to Install
 
-This build is all about flatpak, but also "just files" that you can use on any version of GIMP (.deb,.rpm, Snap, AppImage, Windows, macOS), just check the localization of the GIMP files on every system/package.
+Is very easy to do:
 
-## Preparing the Flatpak enviroment
+##### Linux
 
-* First of all, you need to have the latest GIMP installed on your system [using Flatpak](https://flatpak.org/setup/)
-* Install GIMP Flatpak through your AppCenter/Package Manager or terminal:
-```flatpak install flathub org.gimp.GIMP```
+Run inside the extracted folder:
 
-## Installing this Patch (PhotoGIMP)
+```
+bash install_linux.sh
+```
+
+##### Windows
+
+Double click inside the extracted folder on file:
+
+```
+install_windows.bat
+```
+
+##### Installing manual
 
 Inside of the .zip file from the [releases page](https://github.com/Diolinux/PhotoGIMP/releases) you'll find three hidden folders (on Linux, using the dot before its name). All of this folders has to be extracted on your ```/home/$USER``` folder, overriting everything if you already has the same files from an older installation.
 
@@ -42,12 +59,14 @@ The file has this directories:
 
 * .icons (wich have a new PhotoGIMP icon)
 * .local (wich contain the personalized .desktop file)
-* .var (wich contain the flatpak patch customization for GIMP 2.10+)
+* .var (wich contain the flatpak patch customization for GIMP 2.10+ as flatpak)
 
-If you just want the PhotoGIMP custom without change the original GIMP icon and its name, just extract only the .var folder to your home directory.
+If you just want the PhotoGIMP custom without change the original GIMP icon and its name, just extract only the `.var` folder to your home directory. For installation with other gimp installations, copy the contents of `.var/app/org.gimp.GIMP/config/GIMP/2.10` to the specified gimp profile directory.
 
-## Credits
+### Credits
 
 * This project would't be possible without the amazing GIMP Team.
 * The Photo in the new Splash is from [Isabella Mariana](https://www.pexels.com/pt-br/@isabella-mariana-1022505)
+* The AppImage version is maintaied by [sudo-give-me-coffee](https://github.com/sudo-give-me-coffee/)
 * A BIG thanks to all Diolinux's supporters on [Twitch](https://twitch.tv/Diolinux) and [YouTube](https://youtube.com/Diolinux).
+

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -61,7 +61,7 @@ function installPatch(){
 #   Each common way to use GIMP by popularity
 #
 # Native
-[ -d "${XDG_CONFIG_HOME}/GIMP/2.101/" ] && {
+[ -d "${XDG_CONFIG_HOME}/GIMP/2.10/" ] && {
   installPatch "system repository" "${XDG_CONFIG_HOME}/GIMP/2.10"
 }
 

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+#         Name: PhotoGIMP Instaler
+#       Author: sudo-give-me-coffee
+#  Description: Patches GIMP with a lot of improvment
+#        Usage: bash install_linux.sh
+#
+#-----------------------------------------------------------------------------
+#
+#   Block execution as root
+#
+[ "${EUID}" = 0 ] && {
+    echo
+    echo "This instaler must not be run as root"
+    echo "Run it again as a normal user without sudo:"
+    echo
+    echo "  ${0} ${@}"
+    echo
+    exit 2
+}
+
+#---------------------------------------------------------------------------------------
+#
+#   Useful environment variables to make this script portable
+#
+HERE="$(dirname "$(readlink -f "${0}")")"       # Directory with this script
+
+[ "${XDG_CONFIG_HOME}" = "" ] && {
+  export XDG_CONFIG_HOME="${HOME}/.config"      # Default configuration directory
+}
+
+[ "${XDG_DATA_HOME}" = "" ] && {
+  export XDG_DATA_HOME="${HOME}/.local/share"   # Directory with local custom data
+}
+
+#---------------------------------------------------------------------------------------
+#
+#   Script that does the trick
+#
+function installPatch(){
+  echo "  Instalation from ${1} found..."
+  echo
+  mkdir -p "${2}"
+  cp -rfv "${HERE}/.var/app/org.gimp.GIMP/config/GIMP/2.10/"* "${2}" && {
+    echo
+    echo "PhotoGIMP successfuly installed, have a nice work"
+    echo
+    exit 0
+  } || {
+    echo
+    echo "An error ocurred, run:"
+    echo "  ${0} 2>&1 > report.log"
+    echo
+    echo "To get more info"
+    echo
+    exit 1
+  }
+}
+#---------------------------------------------------------------------------------------
+#
+#   Each common way to use GIMP by popularity
+#
+# Native
+[ -d "${XDG_CONFIG_HOME}/GIMP/2.101/" ] && {
+  installPatch "system repository" "${XDG_CONFIG_HOME}/GIMP/2.10"
+}
+
+# AppImage
+[ -d "${HOME}/.config/GIMP-AppImage/" ] && {
+  installPatch "AppImage" "${HOME}/.config/GIMP-AppImage/"
+}
+
+# Flatpak
+[ -d "${HOME}/.var/app/org.gimp.GIMP/config/GIMP/2.10/" ] && {
+  installPatch "Flatpak" "${HOME}/.config/GIMP-AppImage/"
+}
+
+# Snap
+[ -d "${HOME}/snap/gimp/current/.config/GIMP/2.10/" ] && {
+  installPatch "Snap Store" "${HOME}/snap/gimp/current/.config/GIMP/2.10/"
+}
+

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -72,7 +72,7 @@ function installPatch(){
 
 # Flatpak
 [ -d "${HOME}/.var/app/org.gimp.GIMP/config/GIMP/2.10/" ] && {
-  installPatch "Flatpak" "${HOME}/.config/GIMP-AppImage/"
+  installPatch "Flatpak" "${HOME}/${HOME}/.var/app/org.gimp.GIMP/config/GIMP/2.10/"
 }
 
 # Snap

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -72,7 +72,7 @@ function installPatch(){
 
 # Flatpak
 [ -d "${HOME}/.var/app/org.gimp.GIMP/config/GIMP/2.10/" ] && {
-  installPatch "Flatpak" "${HOME}/${HOME}/.var/app/org.gimp.GIMP/config/GIMP/2.10/"
+  installPatch "Flatpak" "${HOME}/.var/app/org.gimp.GIMP/config/GIMP/2.10/"
 }
 
 # Snap

--- a/install_windows.bat
+++ b/install_windows.bat
@@ -1,0 +1,11 @@
+@echo off
+
+echo "Instalation started..."
+mkdir %userprofile%/.gimp-2.10./AppData/Roaming/Gimp/2.10/
+xcopy /s "%~dp0/.var./app/org.gimp.GIMP/config/GIMP/2.10/" "%userprofile%/.gimp-2.10./AppData/Roaming/Gimp/2.10/"
+
+echo "Instalation finished..."
+
+
+
+


### PR DESCRIPTION
# Esse commit...
### Adiciona https://github.com/Diolinux/PhotoGIMP/commit/0e9273f7a026597394fdeb2fc6c279c7bf922875:

-  O script `install_linux.sh` que identifica o meio usado para instalação (empacotamento nativo, AppImage, Snap e Flatpak) e faz a instalação automatiza do patch
- Suporte inicial ao Windows  através do script `install_windows.bat`

### Remove https://github.com/Diolinux/PhotoGIMP/commit/efd5f5aa5f0babceed0265223f94d67766ee1133

- A posição das caixas de diálogo flutuantes que apareciam "fora da tela" em monitores com resolução mais baixa

### Modifica https://github.com/Diolinux/PhotoGIMP/commit/c613d7c141c063ced6c83f6ad685c28cd242c4da

- A organização das informações no README.md para se adequar ao padrão de projetos do GitHub que fornecem arquivos pronto para download
- As instruções de instalação
- O cabeçalho adicionando um link para baixar a versão AppImage pré empacotada com patch
- A sessão créditos adicionando um link para o meu perfil fazendo referência unicamente a versão AppImage

-------------------------------------

Possíveis issues relacionadas: https://github.com/Diolinux/PhotoGIMP/issues/9, https://github.com/Diolinux/PhotoGIMP/issues/8, https://github.com/Diolinux/PhotoGIMP/issues/7, https://github.com/Diolinux/PhotoGIMP/issues/3 