### PR TITLE
Update base color & first startup settings

### DIFF
--- a/.var/app/org.gimp.GIMP/config/GIMP/2.10/gimprc
+++ b/.var/app/org.gimp.GIMP/config/GIMP/2.10/gimprc
@@ -1,5 +1,5 @@
 # GIMP gimprc
-# 
+#
 # This is your personal gimprc file.  Any variable defined in this file takes
 # precedence over the value defined in the system-wide gimprc:
 # /app/etc/gimp/2.0/gimprc
@@ -41,8 +41,8 @@
     (snap-to-grid no)
     (snap-to-canvas no)
     (snap-to-path no)
-    (padding-mode default)
-    (padding-color (color-rgb 1 1 1))
+    (padding-mode custom)
+    (padding-color (color-rgb 0.098039215686274508 0.098039215686274508 0.098039215686274508))
     (padding-in-show-all no))
 (filter-tool-show-color-options yes)
 (toolbox-wilber no)

--- a/.var/app/org.gimp.GIMP/config/GIMP/2.10/gtkrc
+++ b/.var/app/org.gimp.GIMP/config/GIMP/2.10/gtkrc
@@ -13,11 +13,14 @@
 # You can add your own GIMP-specific GTK styles here.
 
 # Override GIMP Dark Mode
-# gtk-font-name = "Lucida Grande"
+
+# Overall Font Family
+# gtk-font-name = "Sans 10"
 
 style "gimp-dark-default-style"
 {
-  # font_name = "Lucida Grande"
+  # Font Family for Dark Default Style
+  # font_name = "Sans 10"
 
   # Color Variables
   color["clr1"]  = "#DDDDDD"

--- a/.var/app/org.gimp.GIMP/config/GIMP/2.10/gtkrc
+++ b/.var/app/org.gimp.GIMP/config/GIMP/2.10/gtkrc
@@ -12,6 +12,55 @@
 #
 # You can add your own GIMP-specific GTK styles here.
 
+# Override GIMP Dark Mode
+gtk-font-name = "Lucida Grande"
+
+style "gimp-dark-default-style"
+{
+  font_name = "Lucida Grande"
+
+  # Color Variables
+  color["clr1"]  = "#DDDDDD"
+  color["clr2"]  = "#FFFFFF"
+  color["clr3"]  = "#C1C1C1"
+  color["clr4"]  = "#383838"
+  color["clr5"]  = "#555555"
+  color["clr6"]  = "#828282"
+  color["clr7"]  = "#3B3B3B"
+  color["clr8"]  = "#383838"
+  color["clr9"]  = "#353535"
+  color["clrA"]  = "#303030"
+
+  # Foreground
+  fg[NORMAL] = @clr1
+  fg[PRELIGHT] = @clr2
+  fg[ACTIVE] = @clr3
+  fg[SELECTED] = @clr1
+  fg[INSENSITIVE] = @clr3
+
+  # Background
+  bg[NORMAL] = @clr9
+  bg[PRELIGHT] = @clr7
+  bg[ACTIVE] = @clr4
+  bg[SELECTED] = @clr5
+  bg[INSENSITIVE] = @clr5
+
+  # Base Color
+  base[NORMAL] = @clrA
+  base[PRELIGHT] = @clr7
+  base[ACTIVE] = @clr7
+  base[SELECTED] = @clr1
+  base[INSENSITIVE] = @clr8
+
+  # Text Color
+  text[NORMAL] = @clr1
+  text[PRELIGHT] = @clr1
+  text[ACTIVE] = @clr1
+  text[SELECTED] = @clr7
+  text[INSENSITIVE] = @clr9
+}
+
+# END OF GIMP DARK MODE Override
 
 #
 # Adjust the size of previews in plug-in dialogs:

--- a/.var/app/org.gimp.GIMP/config/GIMP/2.10/gtkrc
+++ b/.var/app/org.gimp.GIMP/config/GIMP/2.10/gtkrc
@@ -13,11 +13,11 @@
 # You can add your own GIMP-specific GTK styles here.
 
 # Override GIMP Dark Mode
-gtk-font-name = "Lucida Grande"
+# gtk-font-name = "Lucida Grande"
 
 style "gimp-dark-default-style"
 {
-  font_name = "Lucida Grande"
+  # font_name = "Lucida Grande"
 
   # Color Variables
   color["clr1"]  = "#DDDDDD"

--- a/.var/app/org.gimp.GIMP/config/GIMP/2.10/plug-ins/plugin-heal-selection.py
+++ b/.var/app/org.gimp.GIMP/config/GIMP/2.10/plug-ins/plugin-heal-selection.py
@@ -55,6 +55,7 @@ def heal_selection(timg, tdrawable, samplingRadiusParam=50, directionParam=0, or
 
   # !!! The drawable can be a mask (grayscale channel), don't restrict to layer.
   work_drawable = pdb.gimp_image_get_active_drawable(tempImage)
+
   if not work_drawable:
       raise RuntimeError, "Failed get active drawable"
 
@@ -84,10 +85,12 @@ def heal_selection(timg, tdrawable, samplingRadiusParam=50, directionParam=0, or
 
   # crop the temp image to size of selection to save memory and for directional healing!!
   frisketBounds = grownSelection.mask_bounds
+
   frisketLowerLeftX = frisketBounds[0]
   frisketLowerLeftY = frisketBounds[1]
   frisketUpperRightX = frisketBounds[2]
   frisketUpperRightY = frisketBounds[3]
+
   targetLowerLeftX = targetBounds[0]
   targetLowerLeftY = targetBounds[1]
   targetUpperRightX = targetBounds[2]
@@ -111,6 +114,7 @@ def heal_selection(timg, tdrawable, samplingRadiusParam=50, directionParam=0, or
       # X
       newWidth, newHeight, newLLX, newLLY = ( targetUpperRightX-targetLowerLeftX, frisketHeight,
         targetLowerLeftX, frisketLowerLeftY )
+
   # Restrict crop to image size (condition of gimp_image_crop) eg when off edge of image
   newWidth = min(pdb.gimp_image_width(tempImage) - newLLX, newWidth)
   newHeight = min(pdb.gimp_image_height(tempImage) - newLLY, newHeight)
@@ -122,13 +126,13 @@ def heal_selection(timg, tdrawable, samplingRadiusParam=50, directionParam=0, or
   if not orderParam :
       useBorder = 1   # User wants NO order, ie random filling
   elif orderParam == 1 :  # Inward to corpus.  2,3,4
-      useBorder = directionParam+2   # !!! Offset by 2 to get past the original two boolean values
+      useBorder = directionParam + 2   # !!! Offset by 2 to get past the original two boolean values
   else:
       # Outward from image center.
       # 5+0=5 outward concentric
       # 5+1=6 outward from sides
       # 5+2=7 outward above and below
-      useBorder = directionParam+5
+      useBorder = directionParam + 5
 
   # Note that the old resynthesizer required an inverted selection !!
 
@@ -138,6 +142,7 @@ def heal_selection(timg, tdrawable, samplingRadiusParam=50, directionParam=0, or
       gimp.displays_flush()
     except RuntimeError:  # thrown if non-interactive
       pass
+
     from time import sleep
     sleep(2)
 

--- a/.var/app/org.gimp.GIMP/config/GIMP/2.10/plug-ins/plugin-heal-transparency.py
+++ b/.var/app/org.gimp.GIMP/config/GIMP/2.10/plug-ins/plugin-heal-transparency.py
@@ -31,7 +31,6 @@ gettext.install("resynthesizer", gimp.locale_directory, unicode=True)
 
 
 def heal_transparency(timg, tdrawable, samplingRadiusParam=50, orderParam=2):
-
     # precondition should be enforced by Gimp according to image modes allowed.
     if not pdb.gimp_drawable_has_alpha(tdrawable):
         pdb.gimp_message("The active layer has no alpha channel to heal.")

--- a/.var/app/org.gimp.GIMP/config/GIMP/2.10/plug-ins/plugin-map-style.py
+++ b/.var/app/org.gimp.GIMP/config/GIMP/2.10/plug-ins/plugin-map-style.py
@@ -146,6 +146,7 @@ def make_grayscale_map(image, drawable):
     original_selection = pdb.gimp_selection_save(image)
     pdb.gimp_selection_all(image)  # copy requires selection
     pdb.gimp_edit_copy(drawable)
+
     if original_selection:
         pdb.gimp_selection_load(original_selection)  # restore selection in image
         pdb.gimp_image_remove_channel(
@@ -199,6 +200,7 @@ def copy_selection_to_image(drawable):
     layer_copy = pdb.gimp_image_get_active_layer(image_copy)
     # In earlier version, futzed with selection to deal with transparencey
     display_debug_image(image_copy)
+
     return image_copy, layer_copy
 
 
@@ -227,7 +229,7 @@ def synchronize_contrast(drawable, source_drawable, percent_transfer):
     # 2.5 is from experimentation with gimp_brightness_contrast which seems linear in its effect.
     contrast_control = (mean - source_mean) * 2.5 * (1 - (percent_transfer / 100))
 
-    # clamp to valid range (above formula is lazy, ad hoc)
+    # clamp to valid range
     contrast_control = max(min(contrast_control, 127), -127)
 
     pdb.gimp_brightness_contrast(source_drawable, 0, contrast_control)

--- a/.var/app/org.gimp.GIMP/config/GIMP/2.10/sessionrc
+++ b/.var/app/org.gimp.GIMP/config/GIMP/2.10/sessionrc
@@ -1,5 +1,5 @@
 # GIMP sessionrc
-# 
+#
 # This file takes session-specific info (that is info, you want to keep
 # between two GIMP sessions).  You are not supposed to edit it manually, but
 # of course you can do.  The sessionrc will be entirely rewritten every time
@@ -11,13 +11,13 @@
     (size 620 200))
 (session-info "toplevel"
     (factory-entry "gimp-single-image-window")
-    (position 255 82)
-    (size 1920 856)
+    (position 250 80)
+    (size 1280 720)
     (open-on-exit)
     (aux-info
         (left-docks-width "52")
         (right-docks-width "363")
-        (maximized "no"))
+        (maximized "yes"))
     (gimp-toolbox
         (side left))
     (gimp-dock

--- a/.var/app/org.gimp.GIMP/config/GIMP/2.10/sessionrc
+++ b/.var/app/org.gimp.GIMP/config/GIMP/2.10/sessionrc
@@ -11,12 +11,12 @@
     (size 620 200))
 (session-info "toplevel"
     (factory-entry "gimp-single-image-window")
-    (position 250 80)
+    (position 0 0)
     (size 1280 720)
     (open-on-exit)
     (aux-info
         (left-docks-width "52")
-        (right-docks-width "363")
+        (right-docks-width "372")
         (maximized "yes"))
     (gimp-toolbox
         (side left))
@@ -24,16 +24,20 @@
         (side right)
         (book
             (current-page 0)
-            (dockable "gimp-tool-options"
+            (dockable "gimp-color-editor"
+                (tab-style automatic)
+                (aux-info
+                    (current-page "GimpColorSelect")))
+            (dockable "gimp-font-list"
                 (tab-style automatic)
                 (aux-info
                     (show-button-bar "true")))
-            (dockable "gimp-font-list"
+            (dockable "gimp-tool-options"
                 (tab-style automatic)
                 (aux-info
                     (show-button-bar "true"))))
         (book
-            (position 492)
+            (position 293)
             (current-page 0)
             (dockable "gimp-layer-list"
                 (tab-style automatic)
@@ -41,6 +45,11 @@
                 (aux-info
                     (show-button-bar "true")))
             (dockable "gimp-channel-list"
+                (tab-style automatic)
+                (preview-size 32)
+                (aux-info
+                    (show-button-bar "true")))
+            (dockable "gimp-vectors-list"
                 (tab-style automatic)
                 (preview-size 32)
                 (aux-info

--- a/.var/app/org.gimp.GIMP/config/GIMP/2.10/templaterc
+++ b/.var/app/org.gimp.GIMP/config/GIMP/2.10/templaterc
@@ -1,8 +1,8 @@
 # GIMP templaterc
-# 
+#
 # This file will be entirely rewritten each time you exit.
 
-(GimpTemplate "Imagem blog"
+(GimpTemplate "Diolinux: Blog Post Image"
     (width 800)
     (height 450)
     (unit pixels)
@@ -14,7 +14,7 @@
     (color-managed yes)
     (color-profile NULL)
     (fill-type background)
-    (comment "Created with GIMP"))
+    (comment "Default resolution for Diolinux's blog post images"))
 (GimpTemplate "640x480"
     (width 640)
     (height 480)

--- a/.var/app/org.gimp.GIMP/config/GIMP/2.10/themerc
+++ b/.var/app/org.gimp.GIMP/config/GIMP/2.10/themerc
@@ -2,7 +2,7 @@
 #
 # This file is written on GIMP startup and on every theme change.
 # It is NOT supposed to be edited manually. Edit your personal
-# gtkrc file instead (/home/dio/.var/app/org.gimp.GIMP/config/GIMP/2.10/gtkrc).
+# gtkrc file instead (~/.var/app/org.gimp.GIMP/config/GIMP/2.10/gtkrc).
 
 style "gimp-spin-scale-style"
 {
@@ -13,6 +13,6 @@ class "GimpSpinScale" style "gimp-spin-scale-style"
 
 include "/app/share/gimp/2.0/themes/Dark/gtkrc"
 include "/app/etc/gimp/2.0/gtkrc"
-include "/home/dio/.var/app/org.gimp.GIMP/config/GIMP/2.10/gtkrc"
+include "~/.var/app/org.gimp.GIMP/config/GIMP/2.10/gtkrc"
 
 # end of themerc


### PR DESCRIPTION
Override GTK Dark Settings:
- Add Custom Color Variables
- Change Background Color to "#353535"
- Change Viewport Background to "#191919"
- Add Color & Path as default tools.
- Fix default startup theme (before was loading from @Diolinux personal folder /home/dio)
- Code Format plugin-heal-selection.py