### PR TITLE
docs: rewrite README and translations to be beginner-friendly and comprehensive

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,26 @@
 # 🎨 PhotoGIMP
 
-<img src="./.local/share/icons/hicolor/256x256/256x256.png" align="right" alt="PhotoGimp application icon" title="PhotoGimp application icon">
+<img src="./.local/share/icons/hicolor/256x256/256x256.png" align="right" alt="PhotoGIMP application icon" title="PhotoGIMP application icon">
 
-A patch for optimizing GIMP 3.0+ for Adobe Photoshop users, including features like:
+[![GitHub stars](https://img.shields.io/github/stars/Diolinux/PhotoGIMP?style=social)](https://github.com/Diolinux/PhotoGIMP)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Latest Release](https://img.shields.io/github/v/release/Diolinux/PhotoGIMP)](https://github.com/Diolinux/PhotoGIMP/releases/latest)
 
-* Tool organization to mimic the position of Adobe Photoshop;
-* New Splash Screen;
-* New default settings to maximize space on the canvas;
-* Shortcuts similar to the ones in Photoshop for Windows, following Adobe's Documentation;
-* New icon and Name from custom .desktop file.
+**PhotoGIMP** is a free, community-driven patch that transforms [GIMP](https://www.gimp.org/) (GNU Image Manipulation Program) into a layout that feels familiar to **Adobe Photoshop** users. If you're switching from Photoshop to GIMP and want to feel at home right away, PhotoGIMP is for you.
+
+> **New to GIMP?** GIMP is a free and open-source image editor available for Linux, macOS, and Windows. It can do most things Photoshop can — photo retouching, image composition, graphic design, and more — all for free. PhotoGIMP just makes it *look and feel* more like Photoshop.
+
+---
+
+## ✨ Features
+
+- **Photoshop-like tool layout** — Tools are reorganized to mimic the positions you're used to in Adobe Photoshop.
+- **Custom Splash Screen** — A unique PhotoGIMP splash screen greets you on startup.
+- **Maximized canvas space** — Default settings are optimized to give you the largest possible working area.
+- **Photoshop keyboard shortcuts** — Keyboard shortcuts follow [Adobe's official documentation](https://helpx.adobe.com/photoshop/using/default-keyboard-shortcuts.html) for the Windows version.
+- **Custom icon & name** — A dedicated `.desktop` file gives PhotoGIMP its own icon and app name in your system menu.
+
+---
 
 ## 📷 Screenshots
 
@@ -22,81 +34,280 @@ A patch for optimizing GIMP 3.0+ for Adobe Photoshop users, including features l
   <em>GIMP 3.0 with the PhotoGIMP patch applied</em>
 </p>
 
+---
+
+## 📋 Requirements
+
+Before installing PhotoGIMP, make sure you have:
+
+| Requirement | Details |
+|---|---|
+| **GIMP 3.0 or newer** | Download from: [gimp.org](https://www.gimp.org/downloads/) or [Flathub](https://flathub.org/apps/org.gimp.GIMP) (Linux) |
+| **Run GIMP at least once** | GIMP needs to generate its config files before PhotoGIMP can overwrite them. **Install GIMP → open it → close it → then install PhotoGIMP.** |
+
+---
+
 ## ⚙ How to Install
 
-This patch is originally intended to work with the Flatpak version of GIMP for Linux, but it can be used in almost any package format with no restriction by extracting the files on the correct folders.
+> [!WARNING]
+> **Back up your current GIMP settings before installing!** PhotoGIMP overwrites GIMP's configuration files. If you have custom settings you want to keep, save a backup copy first. See the backup instructions in each section below.
 
+---
 
-### Flatpak (Linux)
-
-In order to install the newest version of PhotoGIMP on your Linux operating system using Flatpak, just follow this simple steps:
+### 🐧 Flatpak (Linux)
 
 <img src="https://skillicons.dev/icons?i=linux" align="right" width="40" />
 
-1. Make sure you already have GIMP installed [from Flathub](https://flathub.org/apps/org.gimp.GIMP);
-2. **Start and quit GIMP after you installed before you continue!**
-3. Download the files from this repository [or just click here](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP-linux.zip);
-4. Extract the content of the zip file on your home folder (`.config` and `.local` - they are the important ones) and overwrite the files if needed;
-5. You're done, enjoy it! :smile:
+#### Backup (optional)
 
-<hr>
+If you want to keep your current GIMP settings, back them up first:
 
-### Windows
+```bash
+cp -r ~/.config/GIMP/3.0 ~/GIMP-3.0-backup
+```
+
+#### Install
+
+1. Make sure you already have GIMP installed [from Flathub](https://flathub.org/apps/org.gimp.GIMP).
+2. **Open GIMP once, then close it** — this creates the config folders that PhotoGIMP needs.
+3. Download the latest release:
+   👉 **[Download PhotoGIMP for Linux (.zip)](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP-linux.zip)**
+4. Extract the `.zip` file **into your home folder** (`~`).
+   - This will place files into `~/.config` and `~/.local`, which are hidden folders.
+   - To see hidden folders in your file manager, press <kbd>Ctrl</kbd> + <kbd>H</kbd>.
+   - When prompted about existing files, choose **"Replace"** or **"Overwrite"**.
+5. Open GIMP — you should see the new PhotoGIMP layout! 🎉
+
+<details>
+<summary><strong>💡 Using a non-Flatpak GIMP?</strong></summary>
+
+If you installed GIMP from your distro's package manager (apt, dnf, pacman, etc.) instead of Flatpak, the config folder is in the same location (`~/.config/GIMP/3.0`), so the steps above still work. Just make sure you have GIMP version 3.0 or newer.
+</details>
+
+---
+
+### 🪟 Windows
 
 <img src="https://skillicons.dev/icons?i=windows" align="right" />
 
-In order to install the newest version of PhotoGIMP on your Windows:
+#### Backup (optional)
 
-1. Make sure you already have [GIMP installed from official website](https://www.gimp.org/downloads/);
-2. **Start and quit GIMP after you installed before you continue!**
-3. Download thes files from this repository or [just click here](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP.zip);
-4. Extract the content from `PhotoGIMP.zip` to a folder of your preference;
-5. Copy the `3.0` folder;
-6. Hold <kbd>Windows</kbd> key and press <kbd>R</kbd> to open the *Execute* dialog;
-7. Type `%APPDATA%\GIMP` into the dialog and press <kbd>Enter</kbd>;
-8. Paste the `3.0` folder inside the GIMP's folder that you just opened;
-9. When prompted about existing files, select "Replace the files in the destination";
-10. You're done, enjoy it! :smile:
+If you want to keep your current GIMP settings, back them up first:
 
-Or install via [Chocolatey](https://chocolatey.org/):
+1. Press <kbd>Windows</kbd> + <kbd>R</kbd> to open the Run dialog.
+2. Type `%APPDATA%\GIMP` and press <kbd>Enter</kbd>.
+3. Copy the entire `3.0` folder to a safe location (e.g., your Desktop).
+
+#### Install
+
+1. Make sure you have [GIMP installed from the official website](https://www.gimp.org/downloads/).
+2. **Open GIMP once, then close it** — this creates the config folders that PhotoGIMP needs.
+3. Download the latest release:
+   👉 **[Download PhotoGIMP for Windows (.zip)](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP.zip)**
+4. Extract the contents of `PhotoGIMP.zip` to any folder (e.g., your Desktop).
+5. Open the extracted folder and **copy the `3.0` folder**.
+6. Press <kbd>Windows</kbd> + <kbd>R</kbd> to open the Run dialog.
+7. Type `%APPDATA%\GIMP` and press <kbd>Enter</kbd> — this opens GIMP's settings folder.
+8. **Paste** the `3.0` folder here.
+9. When prompted about existing files, select **"Replace the files in the destination"**.
+10. Open GIMP — you should see the new PhotoGIMP layout! 🎉
+
+<details>
+<summary><strong>💡 Optional: Change the GIMP shortcut icon</strong></summary>
+
+You can also download [photogimp.ico](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/photogimp.ico) and update the icon on the GIMP shortcut located at:
+
+```
+%appdata%\Microsoft\Windows\Start Menu\Programs\GIMP 3.0.0
+```
+
+Right-click the shortcut → **Properties** → **Change Icon** → browse to the downloaded `.ico` file.
+</details>
+
+<details>
+<summary><strong>🍫 Install via Chocolatey (alternative)</strong></summary>
+
+If you use [Chocolatey](https://chocolatey.org/), you can install PhotoGIMP with a single command:
+
 ```powershell
 choco install photogimp
 ```
+
 Maintained by: [André Augusto](https://github.com/AndreAugustoDev)
+</details>
 
+---
 
-:bulb: Tips:
-- Optionally, you can also download the [photogimp.ico](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/photogimp.ico) and update the icon from the shortcut in `%appdata%\Microsoft\Windows\Start Menu\Programs\GIMP 3.0.0`;
-- If you want to backup your current GIMP settings before installing PhotoGIMP, copy the entire `3.0` folder from `%APPDATA%\GIMP` to a safe location before proceeding with the installation.
-
-### macOS
+### 🍎 macOS
 
 <img src="https://skillicons.dev/icons?i=macos" align="right" />
 
-In order to install the newest version of PhotoGIMP on your macOS:
+#### Backup (optional)
 
-1. Make sure you already have [GIMP installed from official website](https://www.gimp.org/downloads/);
-2. **Start and quit GIMP after you installed before you continue!**
-3. Download the files from this repository or [just click here](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP.zip);
-4. Extract the content from `PhotoGIMP.zip` to a folder of your preference;
-5. Copy the `3.0` folder;
-6. Open Finder, press <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>G</kbd> to open "Go to Folder";
-7. Type `~/Library/Application Support/GIMP` and press <kbd>Enter</kbd>;
-8. If you have a `2.10` folder from a previous installation, delete it to avoid conflicts;
-9. Paste the `3.0` folder inside the GIMP folder;
-10. When prompted about existing files, select "Replace" or "Merge";
-11. You're done, enjoy it! :smile:
+If you want to keep your current GIMP settings, back them up first:
 
-:bulb: Tips:
-- If you want to backup your current GIMP settings before installing PhotoGIMP, copy the entire GIMP folder from `~/Library/Application Support/GIMP` to a safe location before proceeding with the installation.
+1. Open Finder.
+2. Press <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>G</kbd> and go to `~/Library/Application Support/GIMP`.
+3. Copy the entire `GIMP` folder to a safe location (e.g., your Desktop).
 
-## Credits
+#### Install
 
-* This project would not be possible without the amazing GIMP team.
-* A BIG thanks to all Diolinux's supporters on [YouTube](https://youtube.com/Diolinux).
-* Splash screen & icons from [Adriel Filipe Design](https://bento.me/adrielfilipedesign)
+1. Make sure you have [GIMP installed from the official website](https://www.gimp.org/downloads/).
+2. **Open GIMP once, then close it** — this creates the config folders that PhotoGIMP needs.
+3. Download the latest release:
+   👉 **[Download PhotoGIMP for macOS (.zip)](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP.zip)**
+4. Extract the contents of `PhotoGIMP.zip` to any folder (e.g., your Desktop).
+5. Open the extracted folder and **copy the `3.0` folder**.
+6. Open Finder, press <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>G</kbd> to open "Go to Folder".
+7. Type `~/Library/Application Support/GIMP` and press <kbd>Enter</kbd>.
+8. If you see a `2.10` folder from a previous installation, **delete it** to avoid conflicts.
+9. **Paste** the `3.0` folder inside the GIMP folder.
+10. When prompted about existing files, select **"Replace"** or **"Merge"**.
+11. Open GIMP — you should see the new PhotoGIMP layout! 🎉
 
-## Contributors
+---
+
+## 📦 What's Inside the Patch
+
+PhotoGIMP replaces or adds the following files in GIMP's configuration directory:
+
+| File / Folder | What it does |
+|---|---|
+| `shortcutsrc` | Keyboard shortcuts mapped to match Photoshop |
+| `toolrc` | Tool configuration and ordering |
+| `sessionrc` | Window layout and panel positions |
+| `dockrc` | Dock / panel configuration |
+| `gimprc` | General GIMP preferences (canvas, grid, etc.) |
+| `contextrc` | Active tool/color context settings |
+| `splashes/` | Custom PhotoGIMP splash screen |
+| `theme.css` | Minor UI theme adjustments |
+| `templaterc` | Pre-defined canvas templates |
+
+On Linux, the patch also installs:
+- A custom `.desktop` file (app launcher with PhotoGIMP name and icon)
+- A custom application icon in `~/.local/share/icons/`
+
+---
+
+## 🗑 How to Uninstall
+
+To remove PhotoGIMP and restore GIMP to its default state, simply delete GIMP's config folder and reopen GIMP — it will regenerate fresh default settings.
+
+### Linux
+
+```bash
+rm -rf ~/.config/GIMP/3.0
+```
+
+Then open GIMP again — it will create a brand new default configuration.
+
+If you made a backup earlier, restore it instead:
+
+```bash
+cp -r ~/GIMP-3.0-backup ~/.config/GIMP/3.0
+```
+
+### Windows
+
+1. Press <kbd>Windows</kbd> + <kbd>R</kbd>, type `%APPDATA%\GIMP` and press <kbd>Enter</kbd>.
+2. Delete the `3.0` folder.
+3. Open GIMP — it will recreate the default settings.
+
+Or restore your backup by pasting the backed-up `3.0` folder back.
+
+### macOS
+
+1. Open Finder, press <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>G</kbd>.
+2. Go to `~/Library/Application Support/GIMP`.
+3. Delete the `3.0` folder.
+4. Open GIMP — it will recreate the default settings.
+
+Or restore your backup by pasting the backed-up folder back.
+
+---
+
+## ❓ Troubleshooting / FAQ
+
+<details>
+<summary><strong>PhotoGIMP didn't change anything — GIMP looks the same</strong></summary>
+
+- Make sure you extracted the files to the **correct location**. The most common mistake is extracting to the wrong folder.
+- **Linux**: The `.config` and `.local` folders must be in your home directory (`~`). They are hidden — press <kbd>Ctrl</kbd> + <kbd>H</kbd> in your file manager to see them.
+- **Windows**: The `3.0` folder must be inside `%APPDATA%\GIMP`, not next to it.
+- **macOS**: The `3.0` folder must be inside `~/Library/Application Support/GIMP`.
+- Did you **close GIMP** before pasting the files? GIMP may overwrite incoming settings on exit.
+</details>
+
+<details>
+<summary><strong>I get an error when opening GIMP after installing PhotoGIMP</strong></summary>
+
+- This usually means the GIMP version doesn't match. PhotoGIMP is built for **GIMP 3.0+**. If you're running GIMP 2.x, it won't be compatible.
+- Try deleting the config folder and reinstalling — see the [How to Uninstall](#-how-to-uninstall) section.
+</details>
+
+<details>
+<summary><strong>Can I use PhotoGIMP with GIMP 2.10?</strong></summary>
+
+No. This version of PhotoGIMP is designed exclusively for **GIMP 3.0 and newer**. The configuration format changed significantly between GIMP 2.x and 3.x.
+</details>
+
+<details>
+<summary><strong>Will PhotoGIMP delete my custom brushes, fonts, or plug-ins?</strong></summary>
+
+No. PhotoGIMP only replaces configuration files (shortcuts, layout, preferences). Your personal brushes, fonts, gradients, and plug-ins remain untouched.
+</details>
+
+<details>
+<summary><strong>Can I customize the shortcuts after installing PhotoGIMP?</strong></summary>
+
+Absolutely! PhotoGIMP just sets a starting point. You can change any shortcut in GIMP via **Edit → Keyboard Shortcuts**.
+</details>
+
+<details>
+<summary><strong>How do I update PhotoGIMP to a new version?</strong></summary>
+
+Just download the latest release and follow the installation steps again — it will overwrite the previous PhotoGIMP configuration.
+</details>
+
+---
+
+## 🤝 Contributing
+
+Found a bug? Have a suggestion? We'd love your help!
+
+- **Report an issue**: [Open an issue](https://github.com/Diolinux/PhotoGIMP/issues)
+- **Submit a fix**: [Create a pull request](https://github.com/Diolinux/PhotoGIMP/pulls)
+- **Translate**: Help us translate the README into more languages! See the [Translations](#-translations) section.
+
+---
+
+## 🌍 Translations
+
+This README is available in other languages:
+
+- 🇧🇷 [Português (Brazilian Portuguese)](./docs/README_pt.md)
+- 🇵🇱 [Polski (Polish)](./docs/README_pl.md)
+
+Want to add your language? Fork the repo, create a `docs/README_xx.md` file, and submit a pull request!
+
+---
+
+## 🏆 Credits
+
+- This project would not be possible without the amazing [GIMP](https://www.gimp.org/) team.
+- A BIG thanks to all Diolinux's supporters on [YouTube](https://youtube.com/Diolinux).
+- Splash screen & icons from [Adriel Filipe Design](https://bento.me/adrielfilipedesign).
+
+---
+
+## 👥 Contributors
+
 <a align="center" href="https://github.com/Diolinux/PhotoGIMP/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=Diolinux/PhotoGIMP" />
 </a>
+
+---
+
+## 📄 License
+
+PhotoGIMP is licensed under the [GNU General Public License v3.0](./LICENSE).

--- a/docs/README_pl.md
+++ b/docs/README_pl.md
@@ -1,14 +1,26 @@
 # 🎨 PhotoGIMP
 
-<img src="../.local/share/icons/hicolor/256x256/256x256.png" align="right" alt="PhotoGimp application icon" title="PhotoGimp application icon">
+<img src="../.local/share/icons/hicolor/256x256/256x256.png" align="right" alt="Ikona aplikacji PhotoGIMP" title="Ikona aplikacji PhotoGIMP">
 
-Prosta modyfikacja do GIMP-a 3.0+, aby pomóc użytkownikom Adobe Photoshop, zawierająca funkcje takie jak:
+[![GitHub stars](https://img.shields.io/github/stars/Diolinux/PhotoGIMP?style=social)](https://github.com/Diolinux/PhotoGIMP)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Latest Release](https://img.shields.io/github/v/release/Diolinux/PhotoGIMP)](https://github.com/Diolinux/PhotoGIMP/releases/latest)
 
-* Zmiana położenia narzędzi, podobna do Adobe Photoshop-a;
-* Nowy Ekran Ładowania;
-* Nowe domyślne ustawienia, zwiększające przestrzeń roboczą;
-* Skróty klawiaturowe, przypominające z Photoshop-a, wzorowane na dokumentacji Adobe;
-* Nowa ikona i nazwa dla dowolnego pliku .desktop.
+**PhotoGIMP** to darmowa, utrzymywana przez społeczność modyfikacja, która przekształca [GIMP](https://www.gimp.org/) (GNU Image Manipulation Program) w układ znany użytkownikom **Adobe Photoshop**. Jeśli przechodzisz z Photoshopa na GIMP i chcesz od razu poczuć się jak w domu, PhotoGIMP jest dla Ciebie.
+
+> **Nowy w GIMP-ie?** GIMP to darmowy edytor graficzny o otwartym kodzie źródłowym, dostępny na Linuxa, macOS i Windows. Potrafi zrobić większość rzeczy, które robi Photoshop — retusz zdjęć, kompozycja obrazów, projektowanie graficzne i wiele więcej — wszystko za darmo. PhotoGIMP sprawia jedynie, że GIMP *wygląda i działa* bardziej jak Photoshop.
+
+---
+
+## ✨ Funkcje
+
+- **Układ narzędzi w stylu Photoshopa** — Narzędzia są uporządkowane tak, aby naśladować pozycje znane z Adobe Photoshop.
+- **Własny ekran powitalny** — Unikalny ekran powitalny PhotoGIMP wita Cię przy każdym uruchomieniu.
+- **Zmaksymalizowana przestrzeń robocza** — Domyślne ustawienia są zoptymalizowane, aby zapewnić jak największy obszar roboczy.
+- **Skróty klawiaturowe z Photoshopa** — Skróty klawiaturowe zgodne z [oficjalną dokumentacją Adobe](https://helpx.adobe.com/photoshop/using/default-keyboard-shortcuts.html) dla wersji Windows.
+- **Własna ikona i nazwa** — Dedykowany plik `.desktop` nadaje PhotoGIMP własną ikonę i nazwę w menu systemowym.
+
+---
 
 ## 📷 Zrzuty Ekranu
 
@@ -22,73 +34,280 @@ Prosta modyfikacja do GIMP-a 3.0+, aby pomóc użytkownikom Adobe Photoshop, zaw
   <em>GIMP 3.0 z zastosowanym patchem PhotoGIMP</em>
 </p>
 
+---
+
+## 📋 Wymagania
+
+Przed zainstalowaniem PhotoGIMP, upewnij się, że masz:
+
+| Wymaganie | Szczegóły |
+|---|---|
+| **GIMP 3.0 lub nowszy** | Pobierz z: [gimp.org](https://www.gimp.org/downloads/) lub [Flathub](https://flathub.org/apps/org.gimp.GIMP) (Linux) |
+| **Uruchom GIMP co najmniej raz** | GIMP musi wygenerować swoje pliki konfiguracyjne zanim PhotoGIMP będzie mógł je nadpisać. **Zainstaluj GIMP → otwórz go → zamknij go → następnie zainstaluj PhotoGIMP.** |
+
+---
+
 ## ⚙ Jak Zainstalować
 
-Ten patch został pierwotnie opracowany do pracy z wersją Flatpak GIMP-a dla Linuxa, ale może być używany w prawie każdym formacie pakietu bez ograniczeń, poprzez wyodrębnienie plików do odpowiednich folderów.
+> [!WARNING]
+> **Zrób kopię zapasową obecnych ustawień GIMP-a przed instalacją!** PhotoGIMP nadpisuje pliki konfiguracyjne GIMP-a. Jeśli masz własne ustawienia, które chcesz zachować, najpierw zapisz ich kopię zapasową. Zobacz instrukcje tworzenia kopii zapasowej w każdej sekcji poniżej.
 
-### Flatpak (Linux)
+---
 
-Aby zainstalować najnowszą wersję PhotoGIMP na swoim systemie Linux używając Flatpak, wykonaj następujące proste kroki:
+### 🐧 Flatpak (Linux)
 
 <img src="https://skillicons.dev/icons?i=linux" align="right" width="40" />
 
-1. Upewnij się, że masz już zainstalowany GIMP [z Flathub](https://flathub.org/apps/org.gimp.GIMP);
-2. **Uruchom i zamknij GIMP-a po instalacji przed kontynuowaniem!**
-3. Pobierz pliki z tego repozytorium [lub kliknij tutaj](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP-linux.zip);
-4. Rozpakuj zawartość pliku zip do folderu domowego (`.config` i `.local` - to są ważne) i nadpisz pliki jeśli to konieczne;
-5. Gotowe, ciesz się! :smile:
+#### Kopia zapasowa (opcjonalnie)
 
-<hr>
+Jeśli chcesz zachować obecne ustawienia GIMP-a, najpierw zrób kopię zapasową:
 
-### Windows
+```bash
+cp -r ~/.config/GIMP/3.0 ~/GIMP-3.0-backup
+```
+
+#### Instalacja
+
+1. Upewnij się, że masz już zainstalowany GIMP [z Flathub](https://flathub.org/apps/org.gimp.GIMP).
+2. **Otwórz GIMP-a raz, a następnie go zamknij** — to tworzy foldery konfiguracyjne potrzebne dla PhotoGIMP.
+3. Pobierz najnowszą wersję:
+   👉 **[Pobierz PhotoGIMP dla Linux (.zip)](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP-linux.zip)**
+4. Rozpakuj plik `.zip` **do swojego folderu domowego** (`~`).
+   - Umieści to pliki w `~/.config` i `~/.local`, które są folderami ukrytymi.
+   - Aby zobaczyć ukryte foldery w menedżerze plików, naciśnij <kbd>Ctrl</kbd> + <kbd>H</kbd>.
+   - Gdy pojawi się pytanie o istniejące pliki, wybierz **"Zastąp"** lub **"Nadpisz"**.
+5. Otwórz GIMP — powinieneś zobaczyć nowy układ PhotoGIMP! 🎉
+
+<details>
+<summary><strong>💡 Używasz GIMP-a spoza Flatpak?</strong></summary>
+
+Jeśli zainstalowałeś GIMP-a z menedżera pakietów dystrybucji (apt, dnf, pacman, itp.) zamiast z Flatpaka, folder konfiguracyjny znajduje się w tym samym miejscu (`~/.config/GIMP/3.0`), więc powyższe kroki nadal działają. Upewnij się tylko, że masz GIMP w wersji 3.0 lub nowszej.
+</details>
+
+---
+
+### 🪟 Windows
 
 <img src="https://skillicons.dev/icons?i=windows" align="right" />
 
-Aby zainstalować najnowszą wersję PhotoGIMP na Windows:
+#### Kopia zapasowa (opcjonalnie)
 
-1. Upewnij się, że masz już zainstalowany [GIMP ze strony oficjalnej](https://www.gimp.org/downloads/);
-2. **Uruchom i zamknij GIMP-a po instalacji przed kontynuowaniem!**
-3. Pobierz pliki z tego repozytorium lub [kliknij tutaj](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP.zip);
-4. Rozpakuj zawartość pliku `PhotoGIMP.zip` do folderu według własnego wyboru;
-5. Skopiuj folder `3.0`;
-6. Przytrzymaj klawisz <kbd>Windows</kbd> i naciśnij <kbd>R</kbd>, aby otworzyć okno dialogowe *Uruchom*;
-7. Wpisz `%APPDATA%\GIMP` w oknie dialogowym i naciśnij <kbd>Enter</kbd>;
-8. Wklej folder `3.0` do folderu GIMP-a, który właśnie otworzyłeś;
-9. Gdy pojawi się pytanie o istniejące pliki, wybierz "Zastąp pliki w miejscu docelowym";
-10. Gotowe, ciesz się! :smile:
+Jeśli chcesz zachować obecne ustawienia GIMP-a, najpierw zrób kopię zapasową:
 
-:bulb: Wskazówki:
-- Opcjonalnie możesz również pobrać [photogimp.ico](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/photogimp.ico) i zaktualizować ikonę skrótu w `%appdata%\Microsoft\Windows\Start Menu\Programs\GIMP 3.0.0`;
-- Jeśli chcesz wykonać kopię zapasową swoich obecnych ustawień GIMP-a przed instalacją PhotoGIMP, skopiuj cały folder `3.0` z `%APPDATA%\GIMP` w bezpieczne miejsce przed kontynuowaniem instalacji.
+1. Naciśnij <kbd>Windows</kbd> + <kbd>R</kbd>, aby otworzyć okno Uruchom.
+2. Wpisz `%APPDATA%\GIMP` i naciśnij <kbd>Enter</kbd>.
+3. Skopiuj cały folder `3.0` w bezpieczne miejsce (np. na Pulpit).
 
-### macOS
+#### Instalacja
+
+1. Upewnij się, że masz [GIMP zainstalowany ze strony oficjalnej](https://www.gimp.org/downloads/).
+2. **Otwórz GIMP-a raz, a następnie go zamknij** — to tworzy foldery konfiguracyjne potrzebne dla PhotoGIMP.
+3. Pobierz najnowszą wersję:
+   👉 **[Pobierz PhotoGIMP dla Windows (.zip)](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP.zip)**
+4. Rozpakuj zawartość `PhotoGIMP.zip` do dowolnego folderu (np. na Pulpit).
+5. Otwórz rozpakowany folder i **skopiuj folder `3.0`**.
+6. Naciśnij <kbd>Windows</kbd> + <kbd>R</kbd>, aby otworzyć okno Uruchom.
+7. Wpisz `%APPDATA%\GIMP` i naciśnij <kbd>Enter</kbd> — to otworzy folder ustawień GIMP-a.
+8. **Wklej** folder `3.0` tutaj.
+9. Gdy pojawi się pytanie o istniejące pliki, wybierz **"Zastąp pliki w miejscu docelowym"**.
+10. Otwórz GIMP — powinieneś zobaczyć nowy układ PhotoGIMP! 🎉
+
+<details>
+<summary><strong>💡 Opcjonalnie: Zmień ikonę skrótu GIMP-a</strong></summary>
+
+Możesz również pobrać [photogimp.ico](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/photogimp.ico) i zaktualizować ikonę skrótu GIMP-a znajdującego się w:
+
+```
+%appdata%\Microsoft\Windows\Start Menu\Programs\GIMP 3.0.0
+```
+
+Kliknij prawym przyciskiem myszy na skrót → **Właściwości** → **Zmień ikonę** → wskaż pobrany plik `.ico`.
+</details>
+
+<details>
+<summary><strong>🍫 Instalacja przez Chocolatey (alternatywa)</strong></summary>
+
+Jeśli używasz [Chocolatey](https://chocolatey.org/), możesz zainstalować PhotoGIMP jednym poleceniem:
+
+```powershell
+choco install photogimp
+```
+
+Opiekun pakietu: [André Augusto](https://github.com/AndreAugustoDev)
+</details>
+
+---
+
+### 🍎 macOS
 
 <img src="https://skillicons.dev/icons?i=macos" align="right" />
 
-Aby zainstalować najnowszą wersję PhotoGIMP na macOS:
+#### Kopia zapasowa (opcjonalnie)
 
-1. Upewnij się, że masz już zainstalowany [GIMP ze strony oficjalnej](https://www.gimp.org/downloads/);
-2. **Uruchom i zamknij GIMP-a po instalacji przed kontynuowaniem!**
-3. Pobierz pliki z tego repozytorium lub [kliknij tutaj](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP.zip);
-4. Rozpakuj zawartość pliku `PhotoGIMP.zip` do folderu według własnego wyboru;
-5. Skopiuj folder `3.0`;
-6. Otwórz Finder, naciśnij <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>G</kbd>, aby otworzyć "Idź do folderu";
-7. Wpisz `~/Library/Application Support/GIMP` i naciśnij <kbd>Enter</kbd>;
-8. Jeśli masz folder `2.10` z poprzedniej instalacji, usuń go, aby uniknąć konfliktów;
-9. Wklej folder `3.0` do folderu GIMP;
-10. Gdy pojawi się pytanie o istniejące pliki, wybierz "Zastąp" lub "Scal";
-11. Gotowe, ciesz się! :smile:
+Jeśli chcesz zachować obecne ustawienia GIMP-a, najpierw zrób kopię zapasową:
 
-:bulb: Wskazówki:
-- Jeśli chcesz wykonać kopię zapasową swoich obecnych ustawień GIMP-a przed instalacją PhotoGIMP, skopiuj cały folder GIMP z `~/Library/Application Support/GIMP` w bezpieczne miejsce przed kontynuowaniem instalacji.
+1. Otwórz Finder.
+2. Naciśnij <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>G</kbd> i przejdź do `~/Library/Application Support/GIMP`.
+3. Skopiuj cały folder `GIMP` w bezpieczne miejsce (np. na Pulpit).
 
-## Podziękowania
+#### Instalacja
 
-* Ten projekt nie byłby możliwy bez wspaniałego zespołu GIMP-a.
-* Wielkie podziękowania dla wszystkich zwolenników Diolinux na [YouTube](https://youtube.com/Diolinux).
-* Ekran powitalny i ikony od [Adriel Filipe Design](https://bento.me/adrielfilipedesign)
+1. Upewnij się, że masz [GIMP zainstalowany ze strony oficjalnej](https://www.gimp.org/downloads/).
+2. **Otwórz GIMP-a raz, a następnie go zamknij** — to tworzy foldery konfiguracyjne potrzebne dla PhotoGIMP.
+3. Pobierz najnowszą wersję:
+   👉 **[Pobierz PhotoGIMP dla macOS (.zip)](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP.zip)**
+4. Rozpakuj zawartość `PhotoGIMP.zip` do dowolnego folderu (np. na Pulpit).
+5. Otwórz rozpakowany folder i **skopiuj folder `3.0`**.
+6. Otwórz Finder, naciśnij <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>G</kbd>, aby otworzyć "Idź do folderu".
+7. Wpisz `~/Library/Application Support/GIMP` i naciśnij <kbd>Enter</kbd>.
+8. Jeśli masz folder `2.10` z poprzedniej instalacji, **usuń go**, aby uniknąć konfliktów.
+9. **Wklej** folder `3.0` do folderu GIMP.
+10. Gdy pojawi się pytanie o istniejące pliki, wybierz **"Zastąp"** lub **"Scal"**.
+11. Otwórz GIMP — powinieneś zobaczyć nowy układ PhotoGIMP! 🎉
 
-## Współtwórcy
+---
+
+## 📦 Co Zawiera Patch
+
+PhotoGIMP zastępuje lub dodaje następujące pliki w katalogu konfiguracyjnym GIMP-a:
+
+| Plik / Folder | Co robi |
+|---|---|
+| `shortcutsrc` | Skróty klawiaturowe zmapowane tak, aby odpowiadały Photoshopowi |
+| `toolrc` | Konfiguracja i kolejność narzędzi |
+| `sessionrc` | Układ okien i pozycje paneli |
+| `dockrc` | Konfiguracja doków / paneli |
+| `gimprc` | Ogólne preferencje GIMP-a (płótno, siatka, itp.) |
+| `contextrc` | Ustawienia aktywnego narzędzia/koloru |
+| `splashes/` | Własny ekran powitalny PhotoGIMP |
+| `theme.css` | Drobne korekty motywu interfejsu |
+| `templaterc` | Predefiniowane szablony płótna |
+
+Na Linuxie patch instaluje również:
+- Własny plik `.desktop` (launcher z nazwą i ikoną PhotoGIMP)
+- Własną ikonę aplikacji w `~/.local/share/icons/`
+
+---
+
+## 🗑 Jak Odinstalować
+
+Aby usunąć PhotoGIMP i przywrócić GIMP do stanu domyślnego, wystarczy usunąć folder konfiguracyjny GIMP-a i ponownie go otworzyć — wygeneruje on nowe domyślne ustawienia.
+
+### Linux
+
+```bash
+rm -rf ~/.config/GIMP/3.0
+```
+
+Następnie otwórz GIMP ponownie — utworzy on nową domyślną konfigurację.
+
+Jeśli wcześniej zrobiłeś kopię zapasową, przywróć ją:
+
+```bash
+cp -r ~/GIMP-3.0-backup ~/.config/GIMP/3.0
+```
+
+### Windows
+
+1. Naciśnij <kbd>Windows</kbd> + <kbd>R</kbd>, wpisz `%APPDATA%\GIMP` i naciśnij <kbd>Enter</kbd>.
+2. Usuń folder `3.0`.
+3. Otwórz GIMP — odtworzy on domyślne ustawienia.
+
+Lub przywróć kopię zapasową, wklejając folder `3.0` z powrotem.
+
+### macOS
+
+1. Otwórz Finder, naciśnij <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>G</kbd>.
+2. Przejdź do `~/Library/Application Support/GIMP`.
+3. Usuń folder `3.0`.
+4. Otwórz GIMP — odtworzy on domyślne ustawienia.
+
+Lub przywróć kopię zapasową, wklejając folder z powrotem.
+
+---
+
+## ❓ Rozwiązywanie Problemów / FAQ
+
+<details>
+<summary><strong>PhotoGIMP nic nie zmienił — GIMP wygląda tak samo</strong></summary>
+
+- Upewnij się, że rozpakowałeś pliki we **właściwym miejscu**. Najczęstszym błędem jest rozpakowanie do złego folderu.
+- **Linux**: Foldery `.config` i `.local` muszą znajdować się w Twoim katalogu domowym (`~`). Są one ukryte — naciśnij <kbd>Ctrl</kbd> + <kbd>H</kbd> w menedżerze plików, aby je zobaczyć.
+- **Windows**: Folder `3.0` musi znajdować się **wewnątrz** `%APPDATA%\GIMP`, nie obok niego.
+- **macOS**: Folder `3.0` musi znajdować się **wewnątrz** `~/Library/Application Support/GIMP`.
+- Czy **zamknąłeś GIMP-a** przed wklejeniem plików? GIMP może nadpisać przychodzące ustawienia przy zamykaniu.
+</details>
+
+<details>
+<summary><strong>Otrzymuję błąd po otwarciu GIMP-a po zainstalowaniu PhotoGIMP</strong></summary>
+
+- To zwykle oznacza, że wersja GIMP-a nie pasuje. PhotoGIMP jest przeznaczony dla **GIMP 3.0+**. Jeśli używasz GIMP 2.x, nie będzie kompatybilny.
+- Spróbuj usunąć folder konfiguracyjny i zainstalować ponownie — zobacz sekcję [Jak Odinstalować](#-jak-odinstalować).
+</details>
+
+<details>
+<summary><strong>Czy mogę używać PhotoGIMP z GIMP 2.10?</strong></summary>
+
+Nie. Ta wersja PhotoGIMP została zaprojektowana wyłącznie dla **GIMP 3.0 i nowszego**. Format konfiguracji zmienił się znacząco między GIMP 2.x a 3.x.
+</details>
+
+<details>
+<summary><strong>Czy PhotoGIMP usunie moje własne pędzle, czcionki lub wtyczki?</strong></summary>
+
+Nie. PhotoGIMP zastępuje jedynie pliki konfiguracyjne (skróty, układ, preferencje). Twoje osobiste pędzle, czcionki, gradienty i wtyczki pozostają nietknięte.
+</details>
+
+<details>
+<summary><strong>Czy mogę dostosować skróty po zainstalowaniu PhotoGIMP?</strong></summary>
+
+Oczywiście! PhotoGIMP ustawia jedynie punkt wyjścia. Możesz zmienić dowolny skrót w GIMP-ie przez **Edycja → Skróty klawiaturowe**.
+</details>
+
+<details>
+<summary><strong>Jak zaktualizować PhotoGIMP do nowej wersji?</strong></summary>
+
+Wystarczy pobrać najnowszą wersję i ponownie wykonać kroki instalacji — nadpisze to poprzednią konfigurację PhotoGIMP.
+</details>
+
+---
+
+## 🤝 Współpraca
+
+Znalazłeś błąd? Masz sugestię? Chętnie przyjmiemy Twoją pomoc!
+
+- **Zgłoś problem**: [Otwórz issue](https://github.com/Diolinux/PhotoGIMP/issues)
+- **Wyślij poprawkę**: [Utwórz pull request](https://github.com/Diolinux/PhotoGIMP/pulls)
+- **Tłumacz**: Pomóż nam przetłumaczyć README na więcej języków! Zobacz sekcję [Tłumaczenia](#-tłumaczenia).
+
+---
+
+## 🌍 Tłumaczenia
+
+Ten README jest dostępny w innych językach:
+
+- 🇬🇧 [English (Angielski)](../README.md)
+- 🇧🇷 [Português (Portugalski)](./README_pt.md)
+
+Chcesz dodać swój język? Zrób fork repozytorium, utwórz plik `docs/README_xx.md` i wyślij pull request!
+
+---
+
+## 🏆 Podziękowania
+
+- Ten projekt nie byłby możliwy bez wspaniałego zespołu [GIMP-a](https://www.gimp.org/).
+- Wielkie podziękowania dla wszystkich wspierających Diolinux na [YouTube](https://youtube.com/Diolinux).
+- Ekran powitalny i ikony od [Adriel Filipe Design](https://bento.me/adrielfilipedesign).
+
+---
+
+## 👥 Współtwórcy
+
 <a align="center" href="https://github.com/Diolinux/PhotoGIMP/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=Diolinux/PhotoGIMP" />
 </a>
+
+---
+
+## 📄 Licencja
+
+PhotoGIMP jest objęty licencją [GNU General Public License v3.0](../LICENSE).

--- a/docs/README_pt.md
+++ b/docs/README_pt.md
@@ -1,14 +1,26 @@
 # 🎨 PhotoGIMP
 
-<img src="../.local/share/icons/hicolor/256x256/256x256.png" align="right" alt="PhotoGimp application icon" title="PhotoGimp application icon">
+<img src="../.local/share/icons/hicolor/256x256/256x256.png" align="right" alt="Ícone do PhotoGIMP" title="Ícone do PhotoGIMP">
 
-Um patch para otimizar o GIMP 3.0+ para usuários do Adobe Photoshop, incluindo recursos como:
+[![GitHub stars](https://img.shields.io/github/stars/Diolinux/PhotoGIMP?style=social)](https://github.com/Diolinux/PhotoGIMP)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
+[![Latest Release](https://img.shields.io/github/v/release/Diolinux/PhotoGIMP)](https://github.com/Diolinux/PhotoGIMP/releases/latest)
 
-* Organização de ferramentas para imitar a posição do Adobe Photoshop;
-* Nova tela inicial;
-* Novas configurações padrão para maximizar o espaço na tela;
-* Atalhos semelhantes aos do Photoshop para Windows, seguindo a Documentação da Adobe;
-* Novo ícone e nome do arquivo .desktop personalizado.
+**PhotoGIMP** é um patch gratuito e mantido pela comunidade que transforma o [GIMP](https://www.gimp.org/) (GNU Image Manipulation Program) em um layout familiar para usuários do **Adobe Photoshop**. Se você está migrando do Photoshop para o GIMP e quer se sentir em casa imediatamente, o PhotoGIMP é para você.
+
+> **Novo no GIMP?** O GIMP é um editor de imagens gratuito e de código aberto disponível para Linux, macOS e Windows. Ele pode fazer quase tudo que o Photoshop faz — retoque de fotos, composição de imagens, design gráfico e muito mais — tudo de graça. O PhotoGIMP apenas faz com que ele *pareça e funcione* mais como o Photoshop.
+
+---
+
+## ✨ Recursos
+
+- **Layout de ferramentas no estilo Photoshop** — As ferramentas são reorganizadas para imitar as posições que você já conhece do Adobe Photoshop.
+- **Tela Inicial personalizada** — Uma splash screen exclusiva do PhotoGIMP aparece ao iniciar o programa.
+- **Espaço de trabalho maximizado** — As configurações padrão são otimizadas para dar a você a maior área de trabalho possível.
+- **Atalhos de teclado do Photoshop** — Os atalhos seguem a [documentação oficial da Adobe](https://helpx.adobe.com/photoshop/using/default-keyboard-shortcuts.html) para a versão Windows.
+- **Ícone e nome personalizados** — Um arquivo `.desktop` dedicado dá ao PhotoGIMP seu próprio ícone e nome no menu do sistema.
+
+---
 
 ## 📷 Capturas de Tela
 
@@ -22,73 +34,280 @@ Um patch para otimizar o GIMP 3.0+ para usuários do Adobe Photoshop, incluindo 
   <em>GIMP 3.0 com o patch PhotoGIMP aplicado</em>
 </p>
 
+---
+
+## 📋 Requisitos
+
+Antes de instalar o PhotoGIMP, certifique-se de que você tem:
+
+| Requisito | Detalhes |
+|---|---|
+| **GIMP 3.0 ou mais recente** | Baixe em: [gimp.org](https://www.gimp.org/downloads/) ou [Flathub](https://flathub.org/apps/org.gimp.GIMP) (Linux) |
+| **Executar o GIMP pelo menos uma vez** | O GIMP precisa gerar seus arquivos de configuração antes que o PhotoGIMP possa sobrescrevê-los. **Instale o GIMP → abra-o → feche-o → depois instale o PhotoGIMP.** |
+
+---
+
 ## ⚙ Como Instalar
 
-Este patch foi originalmente desenvolvido para funcionar com a versão Flatpak do GIMP para Linux, mas pode ser usado em quase qualquer formato de pacote sem restrição, extraindo os arquivos nas pastas corretas.
+> [!WARNING]
+> **Faça backup das suas configurações atuais do GIMP antes de instalar!** O PhotoGIMP sobrescreve os arquivos de configuração do GIMP. Se você tem configurações personalizadas que deseja manter, salve uma cópia de backup primeiro. Veja as instruções de backup em cada seção abaixo.
 
-### Flatpak (Linux)
+---
 
-Para instalar a versão mais recente do PhotoGIMP no seu sistema Linux usando Flatpak, siga estes passos simples:
+### 🐧 Flatpak (Linux)
 
 <img src="https://skillicons.dev/icons?i=linux" align="right" width="40" />
 
-1. Certifique-se de que você já tem o GIMP instalado [pelo Flathub](https://flathub.org/apps/org.gimp.GIMP);
-2. **Inicie e saia do GIMP após a instalação antes de continuar!**
-3. Baixe os arquivos deste repositório [ou clique aqui](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP-linux.zip);
-4. Extraia o conteúdo do arquivo zip para sua pasta home (`.config` e `.local` - são os importantes) e substitua os arquivos se necessário;
-5. Pronto, aproveite! :smile:
+#### Backup (opcional)
 
-<hr>
+Se você deseja manter suas configurações atuais do GIMP, faça o backup primeiro:
 
-### Windows
+```bash
+cp -r ~/.config/GIMP/3.0 ~/GIMP-3.0-backup
+```
+
+#### Instalação
+
+1. Certifique-se de que o GIMP já está instalado [pelo Flathub](https://flathub.org/apps/org.gimp.GIMP).
+2. **Abra o GIMP uma vez e depois feche-o** — isso cria as pastas de configuração que o PhotoGIMP precisa.
+3. Baixe a versão mais recente:
+   👉 **[Baixar PhotoGIMP para Linux (.zip)](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP-linux.zip)**
+4. Extraia o arquivo `.zip` **na sua pasta pessoal** (`~`).
+   - Isso colocará arquivos em `~/.config` e `~/.local`, que são pastas ocultas.
+   - Para ver pastas ocultas no seu gerenciador de arquivos, pressione <kbd>Ctrl</kbd> + <kbd>H</kbd>.
+   - Quando perguntado sobre arquivos existentes, escolha **"Substituir"** ou **"Sobrescrever"**.
+5. Abra o GIMP — você deverá ver o novo layout do PhotoGIMP! 🎉
+
+<details>
+<summary><strong>💡 Usando um GIMP que não é Flatpak?</strong></summary>
+
+Se você instalou o GIMP pelo gerenciador de pacotes da sua distribuição (apt, dnf, pacman, etc.) em vez do Flatpak, a pasta de configuração está no mesmo local (`~/.config/GIMP/3.0`), então os passos acima ainda funcionam. Apenas certifique-se de que você tem o GIMP versão 3.0 ou mais recente.
+</details>
+
+---
+
+### 🪟 Windows
 
 <img src="https://skillicons.dev/icons?i=windows" align="right" />
 
-Para instalar a versão mais recente do PhotoGIMP no Windows:
+#### Backup (opcional)
 
-1. Certifique-se de que você já tem o [GIMP instalado pelo site oficial](https://www.gimp.org/downloads/);
-2. **Inicie e saia do GIMP após a instalação antes de continuar!**
-3. Baixe os arquivos deste repositório ou [clique aqui](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP.zip);
-4. Extraia o conteúdo de `PhotoGIMP.zip` para uma pasta de sua preferência;
-5. Copie a pasta `3.0`;
-6. Pressione a tecla <kbd>Windows</kbd> e <kbd>R</kbd> para abrir o diálogo *Executar*;
-7. Digite `%APPDATA%\GIMP` no diálogo e pressione <kbd>Enter</kbd>;
-8. Cole a pasta `3.0` dentro da pasta do GIMP que você acabou de abrir;
-9. Quando perguntado sobre arquivos existentes, selecione "Substituir os arquivos no destino";
-10. Pronto, aproveite! :smile:
+Se você deseja manter suas configurações atuais do GIMP, faça o backup primeiro:
 
-:bulb: Dicas:
-- Opcionalmente, você também pode baixar o [photogimp.ico](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/photogimp.ico) e atualizar o ícone do atalho em `%appdata%\Microsoft\Windows\Start Menu\Programs\GIMP 3.0.0`;
-- Se você quiser fazer backup das suas configurações atuais do GIMP antes de instalar o PhotoGIMP, copie toda a pasta `3.0` de `%APPDATA%\GIMP` para um local seguro antes de prosseguir com a instalação.
+1. Pressione <kbd>Windows</kbd> + <kbd>R</kbd> para abrir o diálogo Executar.
+2. Digite `%APPDATA%\GIMP` e pressione <kbd>Enter</kbd>.
+3. Copie toda a pasta `3.0` para um local seguro (ex.: sua Área de Trabalho).
 
-### macOS
+#### Instalação
+
+1. Certifique-se de que o [GIMP está instalado pelo site oficial](https://www.gimp.org/downloads/).
+2. **Abra o GIMP uma vez e depois feche-o** — isso cria as pastas de configuração que o PhotoGIMP precisa.
+3. Baixe a versão mais recente:
+   👉 **[Baixar PhotoGIMP para Windows (.zip)](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP.zip)**
+4. Extraia o conteúdo de `PhotoGIMP.zip` para qualquer pasta (ex.: sua Área de Trabalho).
+5. Abra a pasta extraída e **copie a pasta `3.0`**.
+6. Pressione <kbd>Windows</kbd> + <kbd>R</kbd> para abrir o diálogo Executar.
+7. Digite `%APPDATA%\GIMP` e pressione <kbd>Enter</kbd> — isso abre a pasta de configurações do GIMP.
+8. **Cole** a pasta `3.0` aqui.
+9. Quando perguntado sobre arquivos existentes, selecione **"Substituir os arquivos no destino"**.
+10. Abra o GIMP — você deverá ver o novo layout do PhotoGIMP! 🎉
+
+<details>
+<summary><strong>💡 Opcional: Alterar o ícone do atalho do GIMP</strong></summary>
+
+Você também pode baixar o [photogimp.ico](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/photogimp.ico) e atualizar o ícone no atalho do GIMP localizado em:
+
+```
+%appdata%\Microsoft\Windows\Start Menu\Programs\GIMP 3.0.0
+```
+
+Clique com o botão direito no atalho → **Propriedades** → **Alterar Ícone** → navegue até o arquivo `.ico` baixado.
+</details>
+
+<details>
+<summary><strong>🍫 Instalar via Chocolatey (alternativa)</strong></summary>
+
+Se você usa o [Chocolatey](https://chocolatey.org/), pode instalar o PhotoGIMP com um único comando:
+
+```powershell
+choco install photogimp
+```
+
+Mantido por: [André Augusto](https://github.com/AndreAugustoDev)
+</details>
+
+---
+
+### 🍎 macOS
 
 <img src="https://skillicons.dev/icons?i=macos" align="right" />
 
-Para instalar a versão mais recente do PhotoGIMP no seu macOS:
+#### Backup (opcional)
 
-1. Certifique-se de que você já tem o [GIMP instalado pelo site oficial](https://www.gimp.org/downloads/);
-2. **Inicie e saia do GIMP após a instalação antes de continuar!**
-3. Baixe os arquivos deste repositório ou [clique aqui](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP.zip);
-4. Extraia o conteúdo de `PhotoGIMP.zip` para uma pasta de sua preferência;
-5. Copie a pasta `3.0`;
-6. Abra o Finder, pressione <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>G</kbd> para abrir "Ir para a pasta";
-7. Digite `~/Library/Application Support/GIMP` e pressione <kbd>Enter</kbd>;
-8. Se você tiver uma pasta `2.10` de uma instalação anterior, exclua-a para evitar conflitos;
-9. Cole a pasta `3.0` dentro da pasta do GIMP;
-10. Quando perguntado sobre arquivos existentes, selecione "Substituir" ou "Mesclar";
-11. Pronto, aproveite! :smile:
+Se você deseja manter suas configurações atuais do GIMP, faça o backup primeiro:
 
-:bulb: Dicas:
-- Se você quiser fazer backup das suas configurações atuais do GIMP antes de instalar o PhotoGIMP, copie toda a pasta GIMP de `~/Library/Application Support/GIMP` para um local seguro antes de prosseguir com a instalação.
+1. Abra o Finder.
+2. Pressione <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>G</kbd> e vá para `~/Library/Application Support/GIMP`.
+3. Copie toda a pasta `GIMP` para um local seguro (ex.: sua Área de Trabalho).
 
-## Créditos
+#### Instalação
 
-* Este projeto não seria possível sem a incrível equipe do GIMP.
-* Um GRANDE obrigado a todos os apoiadores do Diolinux no [YouTube](https://youtube.com/Diolinux).
-* Tela inicial e ícones de [Adriel Filipe Design](https://bento.me/adrielfilipedesign)
+1. Certifique-se de que o [GIMP está instalado pelo site oficial](https://www.gimp.org/downloads/).
+2. **Abra o GIMP uma vez e depois feche-o** — isso cria as pastas de configuração que o PhotoGIMP precisa.
+3. Baixe a versão mais recente:
+   👉 **[Baixar PhotoGIMP para macOS (.zip)](https://github.com/Diolinux/PhotoGIMP/releases/download/3.0/PhotoGIMP.zip)**
+4. Extraia o conteúdo de `PhotoGIMP.zip` para qualquer pasta (ex.: sua Área de Trabalho).
+5. Abra a pasta extraída e **copie a pasta `3.0`**.
+6. Abra o Finder, pressione <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>G</kbd> para abrir "Ir para a Pasta".
+7. Digite `~/Library/Application Support/GIMP` e pressione <kbd>Enter</kbd>.
+8. Se você tiver uma pasta `2.10` de uma instalação anterior, **exclua-a** para evitar conflitos.
+9. **Cole** a pasta `3.0` dentro da pasta do GIMP.
+10. Quando perguntado sobre arquivos existentes, selecione **"Substituir"** ou **"Mesclar"**.
+11. Abra o GIMP — você deverá ver o novo layout do PhotoGIMP! 🎉
 
-## Contribuidores
+---
+
+## 📦 O Que Está Incluído no Patch
+
+O PhotoGIMP substitui ou adiciona os seguintes arquivos no diretório de configuração do GIMP:
+
+| Arquivo / Pasta | O que faz |
+|---|---|
+| `shortcutsrc` | Atalhos de teclado mapeados para corresponder ao Photoshop |
+| `toolrc` | Configuração e ordenação de ferramentas |
+| `sessionrc` | Layout de janelas e posições de painéis |
+| `dockrc` | Configuração de painéis / docks |
+| `gimprc` | Preferências gerais do GIMP (canvas, grade, etc.) |
+| `contextrc` | Configurações de ferramenta/cor ativas |
+| `splashes/` | Tela inicial personalizada do PhotoGIMP |
+| `theme.css` | Pequenos ajustes no tema da interface |
+| `templaterc` | Modelos de canvas pré-definidos |
+
+No Linux, o patch também instala:
+- Um arquivo `.desktop` personalizado (lançador com nome e ícone do PhotoGIMP)
+- Um ícone personalizado em `~/.local/share/icons/`
+
+---
+
+## 🗑 Como Desinstalar
+
+Para remover o PhotoGIMP e restaurar o GIMP ao estado padrão, basta excluir a pasta de configuração do GIMP e reabri-lo — ele irá regenerar as configurações padrão.
+
+### Linux
+
+```bash
+rm -rf ~/.config/GIMP/3.0
+```
+
+Depois abra o GIMP novamente — ele criará uma nova configuração padrão.
+
+Se você fez um backup anteriormente, restaure-o:
+
+```bash
+cp -r ~/GIMP-3.0-backup ~/.config/GIMP/3.0
+```
+
+### Windows
+
+1. Pressione <kbd>Windows</kbd> + <kbd>R</kbd>, digite `%APPDATA%\GIMP` e pressione <kbd>Enter</kbd>.
+2. Exclua a pasta `3.0`.
+3. Abra o GIMP — ele irá recriar as configurações padrão.
+
+Ou restaure seu backup colando a pasta `3.0` de volta.
+
+### macOS
+
+1. Abra o Finder, pressione <kbd>Cmd</kbd> + <kbd>Shift</kbd> + <kbd>G</kbd>.
+2. Vá para `~/Library/Application Support/GIMP`.
+3. Exclua a pasta `3.0`.
+4. Abra o GIMP — ele irá recriar as configurações padrão.
+
+Ou restaure seu backup colando a pasta de volta.
+
+---
+
+## ❓ Solução de Problemas / FAQ
+
+<details>
+<summary><strong>O PhotoGIMP não mudou nada — o GIMP está igual</strong></summary>
+
+- Certifique-se de que você extraiu os arquivos no **local correto**. O erro mais comum é extrair na pasta errada.
+- **Linux**: As pastas `.config` e `.local` devem estar no seu diretório pessoal (`~`). Elas são ocultas — pressione <kbd>Ctrl</kbd> + <kbd>H</kbd> no seu gerenciador de arquivos para vê-las.
+- **Windows**: A pasta `3.0` deve estar **dentro** de `%APPDATA%\GIMP`, não ao lado dela.
+- **macOS**: A pasta `3.0` deve estar **dentro** de `~/Library/Application Support/GIMP`.
+- Você **fechou o GIMP** antes de colar os arquivos? O GIMP pode sobrescrever as configurações recebidas ao sair.
+</details>
+
+<details>
+<summary><strong>Recebo um erro ao abrir o GIMP depois de instalar o PhotoGIMP</strong></summary>
+
+- Isso geralmente significa que a versão do GIMP não corresponde. O PhotoGIMP é feito para o **GIMP 3.0+**. Se você está usando o GIMP 2.x, não será compatível.
+- Tente excluir a pasta de configuração e reinstalar — veja a seção [Como Desinstalar](#-como-desinstalar).
+</details>
+
+<details>
+<summary><strong>Posso usar o PhotoGIMP com o GIMP 2.10?</strong></summary>
+
+Não. Esta versão do PhotoGIMP foi projetada exclusivamente para o **GIMP 3.0 e mais recente**. O formato de configuração mudou significativamente entre o GIMP 2.x e 3.x.
+</details>
+
+<details>
+<summary><strong>O PhotoGIMP vai apagar meus pincéis, fontes ou plug-ins personalizados?</strong></summary>
+
+Não. O PhotoGIMP substitui apenas arquivos de configuração (atalhos, layout, preferências). Seus pincéis, fontes, gradientes e plug-ins pessoais permanecem intocados.
+</details>
+
+<details>
+<summary><strong>Posso personalizar os atalhos depois de instalar o PhotoGIMP?</strong></summary>
+
+Com certeza! O PhotoGIMP apenas define um ponto de partida. Você pode alterar qualquer atalho no GIMP em **Editar → Atalhos de Teclado**.
+</details>
+
+<details>
+<summary><strong>Como atualizo o PhotoGIMP para uma nova versão?</strong></summary>
+
+Basta baixar a versão mais recente e seguir os passos de instalação novamente — isso sobrescreverá a configuração anterior do PhotoGIMP.
+</details>
+
+---
+
+## 🤝 Contribuindo
+
+Encontrou um bug? Tem uma sugestão? Adoraríamos sua ajuda!
+
+- **Relatar um problema**: [Abrir uma issue](https://github.com/Diolinux/PhotoGIMP/issues)
+- **Enviar uma correção**: [Criar um pull request](https://github.com/Diolinux/PhotoGIMP/pulls)
+- **Traduzir**: Ajude-nos a traduzir o README para mais idiomas! Veja a seção [Traduções](#-traduções).
+
+---
+
+## 🌍 Traduções
+
+Este README está disponível em outros idiomas:
+
+- 🇬🇧 [English (Inglês)](../README.md)
+- 🇵🇱 [Polski (Polonês)](./README_pl.md)
+
+Quer adicionar seu idioma? Faça um fork do repositório, crie um arquivo `docs/README_xx.md` e envie um pull request!
+
+---
+
+## 🏆 Créditos
+
+- Este projeto não seria possível sem a incrível equipe do [GIMP](https://www.gimp.org/).
+- Um GRANDE obrigado a todos os apoiadores do Diolinux no [YouTube](https://youtube.com/Diolinux).
+- Tela inicial e ícones de [Adriel Filipe Design](https://bento.me/adrielfilipedesign).
+
+---
+
+## 👥 Contribuidores
+
 <a align="center" href="https://github.com/Diolinux/PhotoGIMP/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=Diolinux/PhotoGIMP" />
 </a>
+
+---
+
+## 📄 Licença
+
+PhotoGIMP é licenciado sob a [GNU General Public License v3.0](../LICENSE).


### PR DESCRIPTION
## What changed
### New sections added
- **Beginner-friendly introduction** — Explains what GIMP is and how PhotoGIMP relates to it, so first-time users aren't lost
- **Requirements table** — Clear prerequisites (GIMP 3.0+, must run GIMP once first)
- **"What's Inside the Patch"** — Detailed table explaining every config file PhotoGIMP modifies
- **How to Uninstall** — Per-OS instructions to restore GIMP to defaults or from backup
- **Troubleshooting / FAQ** — Collapsible answers to 6 common questions (wrong folder, version mismatch, GIMP 2.10 compatibility, custom assets safety, shortcut customization, updating)
- **Contributing** — Links to issues and PRs
- **Translations** — Cross-links between all language versions
- **License** — Footer linking to LICENSE file
- **Repo badges** — Stars, license, and latest release badges
### Improved existing sections
- **Backup instructions promoted** — Moved from a small tip at the bottom to a visible `> [!WARNING]` block before install steps, with dedicated backup sub-sections per OS
- **Install steps expanded** — Added "why" explanations (e.g., *"this creates the config folders that PhotoGIMP needs"*), explicit paths, and hidden folder tips for Linux
- **Chocolatey & icon change** — Moved into collapsible `<details>` blocks to reduce clutter
- **Features** — Each feature now has a short description instead of just a bullet title
- **Fixed typos** — e.g., "thes files" → "the files"