### PR TITLE
Fix Flatpak launcher command to avoid breakage on new GIMP versions

### DIFF
--- a/.local/share/applications/org.gimp.GIMP.desktop
+++ b/.local/share/applications/org.gimp.GIMP.desktop
@@ -138,7 +138,7 @@ Comment[zh_CN]=创建图像或编辑照片
 Comment[zh_HK]=建立圖像與編輯照片
 Comment[zh_TW]=建立圖像與編輯照片
 Icon=photogimp
-Exec=/usr/bin/flatpak run --branch=stable --arch=x86_64 --command=gimp-3.0 --file-forwarding org.gimp.GIMP @@u %U @@
+Exec=/usr/bin/flatpak run --branch=stable --arch=x86_64 --command=gimp --file-forwarding org.gimp.GIMP @@u %U @@
 Actions=
 MimeType=image/bmp;image/g3fax;image/gif;image/x-fits;image/x-pcx;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-portable-pixmap;image/x-psd;image/x-sgi;image/x-tga;image/x-xbitmap;image/x-xwindowdump;image/x-xcf;image/x-compressed-xcf;image/x-gimp-gbr;image/x-gimp-pat;image/x-gimp-gih;image/tiff;image/jpeg;image/x-psp;application/postscript;image/png;image/x-icon;image/x-xpixmap;image/x-exr;image/x-webp;image/heif;image/heic;image/svg+xml;application/pdf;image/x-wmf;image/jp2;image/x-xcursor;
 Categories=2DGraphics;GTK;Graphics;RasterGraphics;


### PR DESCRIPTION
## Summary
This updates the Flatpak launcher in `.local/share/applications/org.gimp.GIMP.desktop` from:

`--command=gimp-3.0`

to:

`--command=gimp`

## Why
Using a version-pinned command (`gimp-3.0`) breaks when Flatpak GIMP updates its exported binary name (for example, GIMP 3.2). Users then get:

`bwrap: execvp gimp-3.0: No such file or directory`

`--command=gimp` is version-agnostic and continues to work across minor updates.

## Repro / Validation
- Installed: `org.gimp.GIMP` `3.2.0` (Flathub)
- Old desktop entry failed with `gimp-3.0`.
- Verified working command:
  - `flatpak run --command=gimp org.gimp.GIMP --version`
  - Output: `GNU Image Manipulation Program version 3.2.0`

## Impact
- Fixes startup for users on newer Flatpak GIMP versions.
- No behavior change for users already on compatible versions.

Related context: #167
