### PR TITLE
fix: use generic flatpak command in .desktop (fixes #127)

### DIFF
--- a/.local/share/applications/org.gimp.GIMP.desktop
+++ b/.local/share/applications/org.gimp.GIMP.desktop
@@ -138,7 +138,7 @@ Comment[zh_CN]=创建图像或编辑照片
 Comment[zh_HK]=建立圖像與編輯照片
 Comment[zh_TW]=建立圖像與編輯照片
 Icon=photogimp
-Exec=/usr/bin/flatpak run --branch=stable --arch=x86_64 --command=gimp --file-forwarding org.gimp.GIMP @@u %U @@
+Exec=flatpak run --branch=stable --arch=x86_64 --command=gimp --file-forwarding org.gimp.GIMP @@u %U @@
 Actions=
 MimeType=image/bmp;image/g3fax;image/gif;image/x-fits;image/x-pcx;image/x-portable-anymap;image/x-portable-bitmap;image/x-portable-graymap;image/x-portable-pixmap;image/x-psd;image/x-sgi;image/x-tga;image/x-xbitmap;image/x-xwindowdump;image/x-xcf;image/x-compressed-xcf;image/x-gimp-gbr;image/x-gimp-pat;image/x-gimp-gih;image/tiff;image/jpeg;image/x-psp;application/postscript;image/png;image/x-icon;image/x-xpixmap;image/x-exr;image/x-webp;image/heif;image/heic;image/svg+xml;application/pdf;image/x-wmf;image/jp2;image/x-xcursor;
 Categories=2DGraphics;GTK;Graphics;RasterGraphics;


### PR DESCRIPTION
Addresses #127.

This PR replaces the absolute path /usr/bin/flatpak with a generic flatpak command in the .desktop file, improving compatibility across various Linux distributions (like NixOS).