### PR TITLE
Add install script with GIMP version detection

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,11 +4,103 @@
 
 set -euo pipefail
 
-PhotoGIMP Installer
-===================
-GIMP config directory: /home/johannes/.config/GIMP/3.2
-Backing up current config to: /home/johannes/.config/GIMP/3.2.backup-20260416-120910
-Installing PhotoGIMP config...
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_SRC="$SCRIPT_DIR/.config/GIMP/3.0"
 
-Done! Start GIMP to use PhotoGIMP.
-To restore your previous settings: cp -a '/home/johannes/.config/GIMP/3.2.backup-20260416-120910'/. '/home/johannes/.config/GIMP/3.2'/
+# --- Detect GIMP config directory ---
+
+detect_gimp_config_dir() {
+    local config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+    local base="$config_home/GIMP"
+    local regex='.*/[Gg][Ii][Mm][Pp]/[0-9]+\.[0-9]+'
+
+    if [ -d "$base" ]; then
+        local newest
+        case "$(uname)" in
+            Linux)
+                newest=$(find "$base" -maxdepth 1 -type d -regextype posix-egrep -regex "$regex" 2>/dev/null | sort -V | tail -1) ;;
+            Darwin|*BSD|DragonFly)
+                newest=$(find -E "$base" -maxdepth 1 -type d -regex "$regex" 2>/dev/null | sort -V | tail -1) ;;
+        esac
+        if [ -n "${newest:-}" ]; then
+            echo "$newest"
+            return
+        fi
+    fi
+
+    # Fallback: try to get version from gimp binary
+    local version
+    for cmd in gimp gimp-3.2 gimp-3.0; do
+        if command -v "$cmd" &>/dev/null; then
+            version=$("$cmd" --version 2>/dev/null | grep -oP '\d+\.\d+' | head -1)
+            break
+        fi
+    done
+
+    # Flatpak fallback
+    if [ -z "${version:-}" ] && command -v flatpak &>/dev/null; then
+        version=$(flatpak run org.gimp.GIMP --version 2>/dev/null | grep -oP '\d+\.\d+' | head -1 || true)
+    fi
+
+    if [ -n "${version:-}" ]; then
+        echo "$base/$version"
+    else
+        echo "$base/3.0"
+    fi
+}
+
+# --- Detect StartupWMClass ---
+
+detect_wm_class() {
+    local config_dir="$1"
+    local version
+    version=$(basename "$config_dir")  # e.g. "3.2"
+    echo "gimp-$version"
+}
+
+# --- Main ---
+
+echo "PhotoGIMP Installer"
+echo "==================="
+
+# Check that GIMP has been run at least once
+GIMP_CONFIG=$(detect_gimp_config_dir)
+echo "GIMP config directory: $GIMP_CONFIG"
+
+if [ ! -d "$GIMP_CONFIG" ]; then
+    echo ""
+    echo "Config directory does not exist yet."
+    echo "Please start GIMP once, close it, then run this script again."
+    exit 1
+fi
+
+# Backup existing config
+BACKUP="$GIMP_CONFIG.backup-$(date +%Y%m%d-%H%M%S)"
+echo "Backing up current config to: $BACKUP"
+cp -a "$GIMP_CONFIG" "$BACKUP"
+
+# Copy PhotoGIMP config files
+echo "Installing PhotoGIMP config..."
+cp -a "$CONFIG_SRC"/. "$GIMP_CONFIG"/
+
+# Install desktop file with correct WMClass
+DESKTOP_SRC="$SCRIPT_DIR/.local/share/applications/org.gimp.GIMP.desktop"
+DESKTOP_DST="$HOME/.local/share/applications/org.gimp.GIMP.desktop"
+
+if [ -f "$DESKTOP_SRC" ]; then
+    mkdir -p "$(dirname "$DESKTOP_DST")"
+    WM_CLASS=$(detect_wm_class "$GIMP_CONFIG")
+    sed "s/StartupWMClass=gimp-3\.0/StartupWMClass=$WM_CLASS/" \
+        "$DESKTOP_SRC" > "$DESKTOP_DST"
+    echo "Desktop file installed (StartupWMClass=$WM_CLASS)"
+fi
+
+# Install icons
+if [ -d "$SCRIPT_DIR/.local/share/icons" ]; then
+    cp -a "$SCRIPT_DIR/.local/share/icons"/. "$HOME/.local/share/icons"/
+    echo "Icons installed."
+fi
+
+echo ""
+echo "Done! Start GIMP to use PhotoGIMP."
+echo "To restore your previous settings: cp -a '$BACKUP'/. '$GIMP_CONFIG'/"

--- a/install.sh
+++ b/install.sh
@@ -33,14 +33,14 @@ detect_gimp_config_dir() {
     # Fallback: try to get version from gimp binary
     local version
     for cmd in gimp gimp-3.2 gimp-3.0; do
-        if command -v "$cmd" >/dev/null 2>&1; then
+        if command -v "$cmd" >/dev/null; then
             version=$("$cmd" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1 || true)
             [ -n "${version:-}" ] && break
         fi
     done
 
     # Flatpak fallback
-    if [ -z "${version:-}" ] && command -v flatpak >/dev/null 2>&1; then
+    if [ -z "${version:-}" ] && command -v flatpak >/dev/null; then
         version=$(flatpak run org.gimp.GIMP --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1 || true)
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 # PhotoGIMP installer for Linux
 # Detects the installed GIMP version and copies config files accordingly.
 
-set -euo pipefail
+set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 CONFIG_SRC="$SCRIPT_DIR/.config/GIMP/3.0"
@@ -33,14 +33,14 @@ detect_gimp_config_dir() {
     # Fallback: try to get version from gimp binary
     local version
     for cmd in gimp gimp-3.2 gimp-3.0; do
-        if command -v "$cmd" &>/dev/null; then
+        if command -v "$cmd" >/dev/null 2>&1; then
             version=$("$cmd" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1 || true)
             [ -n "${version:-}" ] && break
         fi
     done
 
     # Flatpak fallback
-    if [ -z "${version:-}" ] && command -v flatpak &>/dev/null; then
+    if [ -z "${version:-}" ] && command -v flatpak >/dev/null 2>&1; then
         version=$(flatpak run org.gimp.GIMP --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1 || true)
     fi
 

--- a/install.sh
+++ b/install.sh
@@ -4,97 +4,11 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-CONFIG_SRC="$SCRIPT_DIR/.config/GIMP/3.0"
+PhotoGIMP Installer
+===================
+GIMP config directory: /home/johannes/.config/GIMP/3.2
+Backing up current config to: /home/johannes/.config/GIMP/3.2.backup-20260416-120910
+Installing PhotoGIMP config...
 
-# --- Detect GIMP config directory ---
-
-detect_gimp_config_dir() {
-    local base="$HOME/.config/GIMP"
-
-    # Find the newest 3.x config directory (GIMP creates it on first run)
-    if [ -d "$base" ]; then
-        local newest
-        newest=$(find "$base" -maxdepth 1 -type d -name '3.*' | sort -V | tail -1)
-        if [ -n "$newest" ]; then
-            echo "$newest"
-            return
-        fi
-    fi
-
-    # Fallback: try to get version from gimp binary
-    local version
-    for cmd in gimp gimp-3.2 gimp-3.0; do
-        if command -v "$cmd" &>/dev/null; then
-            version=$("$cmd" --version 2>/dev/null | grep -oP '\d+\.\d+' | head -1)
-            break
-        fi
-    done
-
-    # Flatpak fallback
-    if [ -z "${version:-}" ] && command -v flatpak &>/dev/null; then
-        version=$(flatpak run org.gimp.GIMP --version 2>/dev/null | grep -oP '\d+\.\d+' | head -1 || true)
-    fi
-
-    if [ -n "${version:-}" ]; then
-        echo "$base/$version"
-    else
-        echo "$base/3.0"
-    fi
-}
-
-# --- Detect StartupWMClass ---
-
-detect_wm_class() {
-    local config_dir="$1"
-    local version
-    version=$(basename "$config_dir")  # e.g. "3.2"
-    echo "gimp-$version"
-}
-
-# --- Main ---
-
-echo "PhotoGIMP Installer"
-echo "==================="
-
-# Check that GIMP has been run at least once
-GIMP_CONFIG=$(detect_gimp_config_dir)
-echo "GIMP config directory: $GIMP_CONFIG"
-
-if [ ! -d "$GIMP_CONFIG" ]; then
-    echo ""
-    echo "Config directory does not exist yet."
-    echo "Please start GIMP once, close it, then run this script again."
-    exit 1
-fi
-
-# Backup existing config
-BACKUP="$GIMP_CONFIG.backup-$(date +%Y%m%d-%H%M%S)"
-echo "Backing up current config to: $BACKUP"
-cp -a "$GIMP_CONFIG" "$BACKUP"
-
-# Copy PhotoGIMP config files
-echo "Installing PhotoGIMP config..."
-cp -a "$CONFIG_SRC"/. "$GIMP_CONFIG"/
-
-# Install desktop file with correct WMClass
-DESKTOP_SRC="$SCRIPT_DIR/.local/share/applications/org.gimp.GIMP.desktop"
-DESKTOP_DST="$HOME/.local/share/applications/org.gimp.GIMP.desktop"
-
-if [ -f "$DESKTOP_SRC" ]; then
-    mkdir -p "$(dirname "$DESKTOP_DST")"
-    WM_CLASS=$(detect_wm_class "$GIMP_CONFIG")
-    sed "s/StartupWMClass=gimp-3\.0/StartupWMClass=$WM_CLASS/" \
-        "$DESKTOP_SRC" > "$DESKTOP_DST"
-    echo "Desktop file installed (StartupWMClass=$WM_CLASS)"
-fi
-
-# Install icons
-if [ -d "$SCRIPT_DIR/.local/share/icons" ]; then
-    cp -a "$SCRIPT_DIR/.local/share/icons"/. "$HOME/.local/share/icons"/
-    echo "Icons installed."
-fi
-
-echo ""
-echo "Done! Start GIMP to use PhotoGIMP."
-echo "To restore your previous settings: cp -a '$BACKUP'/. '$GIMP_CONFIG'/"
+Done! Start GIMP to use PhotoGIMP.
+To restore your previous settings: cp -a '/home/johannes/.config/GIMP/3.2.backup-20260416-120910'/. '/home/johannes/.config/GIMP/3.2'/

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# PhotoGIMP installer for Linux
+# Detects the installed GIMP version and copies config files accordingly.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CONFIG_SRC="$SCRIPT_DIR/.config/GIMP/3.0"
+
+# --- Detect GIMP config directory ---
+
+detect_gimp_config_dir() {
+    local base="$HOME/.config/GIMP"
+
+    # Find the newest 3.x config directory (GIMP creates it on first run)
+    if [ -d "$base" ]; then
+        local newest
+        newest=$(find "$base" -maxdepth 1 -type d -name '3.*' | sort -V | tail -1)
+        if [ -n "$newest" ]; then
+            echo "$newest"
+            return
+        fi
+    fi
+
+    # Fallback: try to get version from gimp binary
+    local version
+    for cmd in gimp gimp-3.2 gimp-3.0; do
+        if command -v "$cmd" &>/dev/null; then
+            version=$("$cmd" --version 2>/dev/null | grep -oP '\d+\.\d+' | head -1)
+            break
+        fi
+    done
+
+    # Flatpak fallback
+    if [ -z "${version:-}" ] && command -v flatpak &>/dev/null; then
+        version=$(flatpak run org.gimp.GIMP --version 2>/dev/null | grep -oP '\d+\.\d+' | head -1 || true)
+    fi
+
+    if [ -n "${version:-}" ]; then
+        echo "$base/$version"
+    else
+        echo "$base/3.0"
+    fi
+}
+
+# --- Detect StartupWMClass ---
+
+detect_wm_class() {
+    local config_dir="$1"
+    local version
+    version=$(basename "$config_dir")  # e.g. "3.2"
+    echo "gimp-$version"
+}
+
+# --- Main ---
+
+echo "PhotoGIMP Installer"
+echo "==================="
+
+# Check that GIMP has been run at least once
+GIMP_CONFIG=$(detect_gimp_config_dir)
+echo "GIMP config directory: $GIMP_CONFIG"
+
+if [ ! -d "$GIMP_CONFIG" ]; then
+    echo ""
+    echo "Config directory does not exist yet."
+    echo "Please start GIMP once, close it, then run this script again."
+    exit 1
+fi
+
+# Backup existing config
+BACKUP="$GIMP_CONFIG.backup-$(date +%Y%m%d-%H%M%S)"
+echo "Backing up current config to: $BACKUP"
+cp -a "$GIMP_CONFIG" "$BACKUP"
+
+# Copy PhotoGIMP config files
+echo "Installing PhotoGIMP config..."
+cp -a "$CONFIG_SRC"/. "$GIMP_CONFIG"/
+
+# Install desktop file with correct WMClass
+DESKTOP_SRC="$SCRIPT_DIR/.local/share/applications/org.gimp.GIMP.desktop"
+DESKTOP_DST="$HOME/.local/share/applications/org.gimp.GIMP.desktop"
+
+if [ -f "$DESKTOP_SRC" ]; then
+    mkdir -p "$(dirname "$DESKTOP_DST")"
+    WM_CLASS=$(detect_wm_class "$GIMP_CONFIG")
+    sed "s/StartupWMClass=gimp-3\.0/StartupWMClass=$WM_CLASS/" \
+        "$DESKTOP_SRC" > "$DESKTOP_DST"
+    echo "Desktop file installed (StartupWMClass=$WM_CLASS)"
+fi
+
+# Install icons
+if [ -d "$SCRIPT_DIR/.local/share/icons" ]; then
+    cp -a "$SCRIPT_DIR/.local/share/icons"/. "$HOME/.local/share/icons"/
+    echo "Icons installed."
+fi
+
+echo ""
+echo "Done! Start GIMP to use PhotoGIMP."
+echo "To restore your previous settings: cp -a '$BACKUP'/. '$GIMP_CONFIG'/"

--- a/install.sh
+++ b/install.sh
@@ -11,41 +11,48 @@ CONFIG_SRC="$SCRIPT_DIR/.config/GIMP/3.0"
 
 detect_gimp_config_dir() {
     local config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
-    local base="$config_home/GIMP"
-    local regex='.*/[Gg][Ii][Mm][Pp]/[0-9]+\.[0-9]+'
+    local flatpak_config="$HOME/.var/app/org.gimp.GIMP/config"
+    local regex='.*/[0-9]+\.[0-9]+'
+    local newest
 
-    if [ -d "$base" ]; then
-        local newest
+    # Search native and Flatpak config locations
+    for base in "$config_home/GIMP" "$flatpak_config/GIMP"; do
+        [ -d "$base" ] || continue
         case "$(uname)" in
             Linux)
-                newest=$(find "$base" -maxdepth 1 -type d -regextype posix-egrep -regex "$regex" 2>/dev/null | sort -V | tail -1) ;;
+                newest=$(find "$base" -maxdepth 1 -type d -regextype posix-egrep -regex "$regex" 2>/dev/null | sort -t. -k1,1n -k2,2n | tail -1) ;;
             Darwin|*BSD|DragonFly)
-                newest=$(find -E "$base" -maxdepth 1 -type d -regex "$regex" 2>/dev/null | sort -V | tail -1) ;;
+                newest=$(find -E "$base" -maxdepth 1 -type d -regex "$regex" 2>/dev/null | sort -t. -k1,1n -k2,2n | tail -1) ;;
         esac
         if [ -n "${newest:-}" ]; then
             echo "$newest"
             return
         fi
-    fi
+    done
 
     # Fallback: try to get version from gimp binary
     local version
     for cmd in gimp gimp-3.2 gimp-3.0; do
         if command -v "$cmd" &>/dev/null; then
-            version=$("$cmd" --version 2>/dev/null | grep -oP '\d+\.\d+' | head -1)
-            break
+            version=$("$cmd" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1 || true)
+            [ -n "${version:-}" ] && break
         fi
     done
 
     # Flatpak fallback
     if [ -z "${version:-}" ] && command -v flatpak &>/dev/null; then
-        version=$(flatpak run org.gimp.GIMP --version 2>/dev/null | grep -oP '\d+\.\d+' | head -1 || true)
+        version=$(flatpak run org.gimp.GIMP --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+' | head -1 || true)
     fi
 
     if [ -n "${version:-}" ]; then
-        echo "$base/$version"
+        # Prefer Flatpak path if it exists
+        if [ -d "$flatpak_config/GIMP" ]; then
+            echo "$flatpak_config/GIMP/$version"
+        else
+            echo "$config_home/GIMP/$version"
+        fi
     else
-        echo "$base/3.0"
+        echo "$config_home/GIMP/3.0"
     fi
 }
 


### PR DESCRIPTION
## Problem

PhotoGIMP config is hardcoded to `~/.config/GIMP/3.0/`. When GIMP updates to 3.2, it looks in `~/.config/GIMP/3.2/` and the PhotoGIMP layout is gone. The `.desktop` file has `StartupWMClass=gimp-3.0` which also breaks.

This comes up in #166 and #181 - and it will happen again with every GIMP minor version bump.

## Solution

A simple `install.sh` that:
- Finds the active GIMP config directory (newest `3.x` folder)
- Creates a timestamped backup before copying
- Adjusts `StartupWMClass` in the `.desktop` file to match the installed version
- Works with native packages, Flatpak, and AppImage

Usage:
```bash
git clone https://github.com/Diolinux/PhotoGIMP.git
cd PhotoGIMP
./install.sh
```

Fixes #166, fixes #181